### PR TITLE
Fixed up the micronets gw service file to reflect the installed location of the gw service

### DIFF
--- a/micronets-gw-service/micronets-gw.service
+++ b/micronets-gw-service/micronets-gw.service
@@ -4,8 +4,8 @@ After=network-online.target
 
 [Service]
 Type=idle
-WorkingDirectory=/opt/micronets/gw-service
-ExecStart=/opt/micronets/gw-service/virtualenv/bin/python runner.py --config config.MockDevelopmentConfig
+WorkingDirectory=/opt/micronets/opt/micronets-gw
+ExecStart=/opt/micronets-gw/virtualenv/bin/python runner.py --config config.DnsmasqTestingConfig
 # User=micronets
 # Group=micronets
 StandardOutput=syslog


### PR DESCRIPTION
We should probably consider patching the .service file at build-time
 to ensure it's in sync with the install path.

Tested this on my test gateway. The service was able to startup and run
 via systemd.