### PR TITLE
Add hostapd cli adapter

### DIFF
--- a/micronets-gw-service/app/__init__.py
+++ b/micronets-gw-service/app/__init__.py
@@ -20,6 +20,8 @@ class MyRequest (Request):
 class MyQuart (Quart):
     request_class = MyRequest
 
+logger = logging.getLogger ('micronets-gw-service')
+
 # create application instance
 app = MyQuart (__name__)
 
@@ -47,16 +49,20 @@ logging.basicConfig (level=logging_level, filename=logging_filename, filemode=lo
                      format='%(asctime)s %(name)s: %(levelname)s %(message)s')
 print (f"Logging to logfile {logging_filename} (level {logging_level})")
 
-logger = logging.getLogger ('micronets-gw-service')
-
 logger.info (f"Loading app module using {config}")
 
 dhcp_conf_model = None
 dhcp_adapter = None
-ws_connection = None
+ws_connector = None
+
+def get_logger():
+    return logger
 
 def get_dhcp_conf_model ():
     return dhcp_conf_model
+
+def get_ws_connector():
+    return ws_connector
 
 if not 'DHCP_ADAPTER' in app.config:
     exit (f"A DHCP_ADAPTER must be defined in the selected configuration ({app.config})")
@@ -77,24 +83,37 @@ elif adapter == "DNSMASQ":
 else:
     exit ("Unrecognized adapter type ({})".format (adapter))
 
-from .ws_connection import WSConnector
+from .ws_connector import WSConnector
 
 try:
-    ws_connection_enabled = app.config['WEBSOCKET_CONNECTION_ENABLED']
+    ws_connector_enabled = app.config['WEBSOCKET_CONNECTION_ENABLED']
     ws_server_address = app.config ['WEBSOCKET_SERVER_ADDRESS']
     ws_server_port = app.config ['WEBSOCKET_SERVER_PORT']
     ws_server_path = app.config ['WEBSOCKET_SERVER_PATH']
     ws_tls_certkey_file = app.config['WEBSOCKET_TLS_CERTKEY_FILE']
     ws_tls_ca_cert_file = app.config['WEBSOCKET_TLS_CA_CERT_FILE']
-    ws_connection = WSConnector (ws_server_address, ws_server_port, ws_server_path,
-                                 tls_certkey_file=ws_tls_certkey_file,
-                                 tls_ca_file=ws_tls_ca_cert_file)
-    if ws_connection_enabled:
-        ws_connection.connect ()
+    ws_connector = WSConnector (ws_server_address, ws_server_port, ws_server_path,
+                                tls_certkey_file=ws_tls_certkey_file,
+                                tls_ca_file=ws_tls_ca_cert_file)
+    if ws_connector_enabled:
+        ws_connector.connect ()
     else:
         logger.info("Not initiating websocket connection (Websocket connection disabled)")
 except Exception as ex:
     logger.info ("Error starting websocket connector:", exc_info=True)
+    exit (1)
+
+from .dpp_handler import DPPHandler
+
+try:
+    dpp_handler_enabled = app.config['DPP_HANDLER_ENABLED']
+    dpp_handler = DPPHandler ()
+    if dpp_handler_enabled:
+        ws_connector.register_handler (dpp_handler)
+    else:
+        logger.info("Not initiating dpp handler (DPP handler or Websocket connection disabled)")
+except Exception as ex:
+    logger.info ("Error registering DPP handler:", exc_info=True)
     exit (1)
 
 from .dhcp_conf import DHCPConf
@@ -113,7 +132,7 @@ except Exception as ex:
 try:
     min_dhcp_conf_update_int_s = app.config ['MIN_DHCP_UPDATE_INTERVAL_S']
     logger.info (f"Minimum DHCP update interval (seconds): {min_dhcp_conf_update_int_s}")
-    dhcp_conf_model = DHCPConf (ws_connection, dhcp_adapter, flow_adapter, min_dhcp_conf_update_int_s)
+    dhcp_conf_model = DHCPConf (ws_connector, dhcp_adapter, flow_adapter, min_dhcp_conf_update_int_s)
 except Exception as ex:
     logger.info ("Error starting with adapter:", exc_info=True)
     exit (1)

--- a/micronets-gw-service/app/__init__.py
+++ b/micronets-gw-service/app/__init__.py
@@ -116,6 +116,22 @@ except Exception as ex:
     logger.info ("Error registering DPP handler:", exc_info=True)
     exit (1)
 
+from .hostapd_adapter import HostapdAdapter
+
+try:
+    hostapd_adapter_enabled = app.config['HOSTAPD_ADAPTER_ENABLED']
+    hostapd_adapter = None
+    if hostapd_adapter_enabled:
+        hostapd_cli_path = app.config['HOSTAPD_CLI_PATH']
+        logger.info(f"hostapd adapter enabled (hostapd cli path {hostapd_cli_path})")
+        hostapd_adapter = HostapdAdapter(hostapd_cli_path)
+        asyncio.ensure_future(hostapd_adapter.connect())
+    else:
+        logger.info("Not initiating hostapd adapter (disabled via config)")
+except Exception as ex:
+    logger.info ("Error starting hostapd adapter:", exc_info=True)
+    exit (1)
+
 from .dhcp_conf import DHCPConf
 
 flow_adapter = None

--- a/micronets-gw-service/app/dhcp_conf.py
+++ b/micronets-gw-service/app/dhcp_conf.py
@@ -14,8 +14,8 @@ import logging
 logger = logging.getLogger ('micronets-gw-service')
 
 class DHCPConf:
-    def __init__ (self, ws_connection, dhcp_adapter, flow_adapter, min_update_interval_s):
-        self.ws_connection = ws_connection
+    def __init__ (self, ws_connector, dhcp_adapter, flow_adapter, min_update_interval_s):
+        self.ws_connector = ws_connector
         self.dhcp_adapter = dhcp_adapter
         self.flow_adapter = flow_adapter
         self.min_update_interval_s = min_update_interval_s
@@ -322,8 +322,8 @@ class DHCPConf:
         event_fields = dhcp_lease_event ['leaseChangeEvent']
         action = event_fields ['action']
 
-        if not self.ws_connection.is_ready ():
-            ws_uri = self.ws_connection.get_connect_uri ()
+        if not self.ws_connector.is_ready ():
+            ws_uri = self.ws_connector.get_connect_uri ()
             logger.info (f"DHCPConf.process_dhcp_lease_event: Cannot send {action} event - the websocket to {ws_uri} is not connected/ready")
             return f"The websocket connection to {ws_uri} is not connected/ready", 500
 
@@ -342,5 +342,5 @@ class DHCPConf:
                              }
         logger.info (f"DHCPConf.process_dhcp_lease_event: Sending: {action}")
         logger.info (json.dumps (lease_change_event, indent=4))
-        await self.ws_connection.send_event_message ("DHCP", action, lease_change_event)
+        await self.ws_connector.send_event_message ("DHCP", action, lease_change_event)
         return '', 200

--- a/micronets-gw-service/app/dpp_handler.py
+++ b/micronets-gw-service/app/dpp_handler.py
@@ -1,0 +1,20 @@
+import asyncio
+import websockets
+import pathlib
+import ssl
+import multidict
+import logging
+
+from quart import Quart, Request, json
+from app import app
+from .utils import check_json_field
+from .ws_connector import WSHandler
+
+logger = logging.getLogger ('micronets-gw-service')
+
+class DPPHandler(WSHandler):
+    def __init__ (self):
+        super().__init__("DPP")
+
+    async def handle_message(self, message):
+        logger.info("DPPHandler.handle_message: {message}")

--- a/micronets-gw-service/app/hostapd_adapter.py
+++ b/micronets-gw-service/app/hostapd_adapter.py
@@ -6,7 +6,10 @@ import inspect
 import time
 import fcntl
 import os
+import subprocess
+import threading
 from asyncio import BaseTransport, ReadTransport, WriteTransport, SubprocessTransport
+from subprocess import Popen, PIPE
 
 logger = logging.getLogger ('hostapd_adapter')
 
@@ -15,104 +18,36 @@ class HostapdAdapter:
     def __init__ (self, hostapd_cli_path, hostapd_cli_args=()):
         self.hostapd_cli_path = hostapd_cli_path
         self.hostapd_cli_args = hostapd_cli_args
-        self.hostapd_proc = None
-        self.transport = None
-        self.protocol = None
+        self.hostapd_cli_process = None
+        self.process_reader_thread = None
 
 
     async def connect(self):
         logger.info(f"HostapdAdapter:connect()")
         event_loop = asyncio.get_event_loop ()
         logger.info(f"HostapdAdapter:connect: Running {self.hostapd_cli_path} {self.hostapd_cli_args}")
-#        code = "import time,datetime; print(datetime.datetime.now());time.sleep(4);print(datetime.datetime.now());time.sleep(4);print(datetime.datetime.now());"
-#        code = 'import time,datetime; \nwhile True: \n\tprint(datetime.datetime.now())\n\ttime.sleep(1)\n'
-        transport, protocol = await event_loop.subprocess_exec(HostapdConnection, 
-                                                               self.hostapd_cli_path, *self.hostapd_cli_args,
-                                                               stdout=asyncio.subprocess.PIPE, 
-                                                               stderr=asyncio.subprocess.STDOUT, 
-                                                               stdin=asyncio.subprocess.PIPE,
-                                                               encoding="utf-8")
-        logger.info(f"HostapdAdapter:connect: subprocess_exec returned: transport {transport}, protocol {protocol}")
-        self.transport = transport
-        self.protocol = protocol
-        protocol.stdin.writelines([b"help()\n   "])
-        # protocol.stdin_pipe.flush()
-        # protocol.stdout_pipe.flush()
-        # time.sleep(1)
-        # protocol.stdin.writelines([b"topics\n"])
-        # time.sleep(1)
-        # protocol.stdin.writelines([b"modules\n"])
-        # time.sleep(1)
-        # protocol.stdin.write_eof()
-        logger.info(f"HostapdAdapter:connect done")
+        
+        self.hostapd_cli_process = Popen([self.hostapd_cli_path, *self.hostapd_cli_args],
+                                         shell=False, bufsize=1,
+                                         stdin=PIPE, stdout=PIPE, stderr=subprocess.STDOUT)
 
-#async def relay_messages(self):
-#        logger.info(f"HostapdAdapter:relay_messages()")
-#        done, pending = await asyncio.wait ([self.read_stdout(), self.read_stderr(), self.write_stdin()],
-#                                            return_when=asyncio.FIRST_COMPLETED)
-#        logger.info(f"HostapdAdapter:relay_messages done")
+        self.process_reader_thread = threading.Thread(target=self.read_process_data)
+        self.process_reader_thread.start()
 
 
-class HostapdConnection (asyncio.Protocol):
-    def __init__(self):
-        logger.info(f"HostapdConnection constructed")
-        self.transport = None
-        self.stdin = None
-        self.stdin_pipe = None
-        self.stdout = None
+    def read_process_data(self):
+        while True:
+            try:
+                data = self.hostapd_cli_process.stdout.readline().decode("utf-8")
+                if not data:
+                    break
+                logger.info(f"HostapdAdapter:read_process_data: Read data: {data.rstrip()}")
+            except Exception as ex:
+                logger.warning(f"HostapdAdapter:read_process_data: Error processing data: {ex}")
 
-    def connection_made(self, transport):
-        logger.info(f"HostapdConnection:connection_made(transport: {transport})")
-        if transport:
-            self.transport = transport
-            self.protocol = transport.get_protocol()
-            logger.info(f"HostapdConnection:connection_made:   protocol: {self.protocol}")
-            logger.info(f"HostapdConnection:connection_made:   transport type: {type(transport)}")
-            
-            if isinstance(transport, asyncio.ReadTransport):
-                logger.info(f"HostapdConnection:connection_made:   transport is a ReadTransport")
-            if isinstance(transport, asyncio.WriteTransport):
-                logger.info(f"HostapdConnection:connection_made:   transport is a WriteTransport")
-            if isinstance(transport, asyncio.SubprocessTransport):
-                logger.info(f"HostapdConnection:connection_made:   transport is a SubprocessTransport")
-                self.stdin = transport.get_pipe_transport(0)
-                logger.info(f"HostapdConnection:connection_made:     stdin: {self.stdin}")
-                logger.info(f"HostapdConnection:connection_made:     stdin: write_buffer_limit: {self.stdin.get_write_buffer_limits()}")
-                # self.stdin.set_write_buffer_limits(10, 1)
-                logger.info(f"HostapdConnection:connection_made:     stdin: adjusted write_buffer_limit: {self.stdin.get_write_buffer_limits()}")
-                logger.info(f"HostapdConnection:connection_made:     stdin: write_buffer_size: {self.stdin.get_write_buffer_size()}")
-                self.stdin_pipe = self.stdin.get_extra_info("pipe", None)
-                logger.info(f"HostapdConnection:connection_made:     stdin: pipe: {self.stdin_pipe}")
-                logger.info(f"HostapdConnection:connection_made:     stdin: fileno: {self.stdin_pipe.fileno()}")
-                # logger.info(f"HostapdConnection:connection_made:     stdin members: {inspect.getmembers (self.stdin_pipe)}")
-                # make stdin non-blocking 
-                fl = fcntl.fcntl(self.stdin_pipe, fcntl.F_GETFL)
-                fcntl.fcntl(self.stdin_pipe, fcntl.F_SETFL, fl | os.O_NONBLOCK)
-                self.stdout = transport.get_pipe_transport(1)
-                logger.info(f"HostapdConnection:connection_made:     stdout: {self.stdout}")
-                self.stdout_pipe = self.stdout.get_extra_info("pipe", None)
-                logger.info(f"HostapdConnection:connection_made:     stdout: pipe: {self.stdout_pipe}")
-                logger.info(f"HostapdConnection:connection_made:     stdout: resuming reading")
-
-                fd = self.stdout_pipe.fileno()
-                fl = fcntl.fcntl(fd, fcntl.F_GETFL)
-                fcntl.fcntl(fd, fcntl.F_SETFL, fl | os.O_NONBLOCK)
-                # logger.info(f"HostapdConnection:connection_made:     stdin members: {inspect.getmembers (self.stdin)}")
-
-    def pipe_data_received(self, fd, data):
-        logger.info(f"HostapdConnection:pipe_data_received(fd: {fd}, data: {data})")
-    
-    def pipe_connection_lost(self, fd, exc):
-        logger.info(f"HostapdConnection:pipe_connection_lost(fd: {fd}, exc: {exc})")
-    
-    def process_exited(self):
-        logger.info(f"HostapdConnection:process_exited()")
-    
-    def error_received(self, exc):
-        logger.info(f"HostapdConnection:error_received(exc: {exc})")
-
-    def connection_lost(self, exc):
-        logger.info(f"HostapdConnection:connection_lost(exc: {exc})")
+    def send_command(self, message):
+        self.hostapd_cli_process.stdin.write((message + '\n').encode())	
+        self.hostapd_cli_process.stdin.flush()
 
 if __name__ == '__main__':
     print (f"{__name__}: Starting\n")
@@ -123,15 +58,17 @@ if __name__ == '__main__':
 
     event_loop = asyncio.get_event_loop ()
     try:
-        logger.info (f"Starting event loop...")
+        logger.info (f"{__name__}: Starting event loop...")
 #        hostapd_adapter = HostapdAdapter("/usr/bin/tail", ["-f", "-n", "1", "/var/log/syslog"])
-        hostapd_adapter = HostapdAdapter("/usr/bin/python", ["-u"])
+        hostapd_adapter = HostapdAdapter("/opt/micronets-hostapd/bin/hostapd_cli", [])
         event_loop.run_until_complete(hostapd_adapter.connect())
-        event_loop.run_forever()
+        logger.info (f"{__name__}: Connected.")
+        time.sleep(2)
+        logger.info (f"{__name__}: Issuing help command...")
+        hostapd_adapter.send_command("help")
 #        event_loop.run_until_complete(hostapd_adapter.relay_messages())
         event_loop.run_forever()
     except Exception as Ex:
         logger.warn (f"Caught an exception: {Ex}")
-        traceback.print_exc (file=sys.stdout)
-    
+
 

--- a/micronets-gw-service/app/hostapd_adapter.py
+++ b/micronets-gw-service/app/hostapd_adapter.py
@@ -53,7 +53,7 @@ class HostapdAdapter:
                 line = data.decode("utf-8")
                 if len(line) == 0:
                     continue
-                # logger.debug(f"HostapdAdapter:read_process_data: Read line: \"{line}\"")
+                logger.debug(f"HostapdAdapter:read_process_data: \"{line[:-1]}\"")
                 cli_event_match = HostapdAdapter.cli_event_re.match(line)
                 if cli_event_match:
                     event_data = cli_event_match.group(2)
@@ -259,7 +259,7 @@ async def run_tests():
         configurator_id = await add_config_id_cmd.get_configurator_id()
         logger.info (f"{__name__}: DPP Configurator ID: {configurator_id}")
 
-        await asyncio.sleep(2)
+        # await asyncio.sleep(2)
         qrcode = "DPP:C:81/1;M:2c:d0:5a:6e:ca:3c;I:KYZRQ;K:MDkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDIgAC/nFQKV1+CErzr6QCUT0jFIno3CaTRr3BW2n0ThU4mAw=;;"
         logger.info (f"{__name__}: Issuing DPP Add QRCode command...")
         logger.info (f"{__name__}:   Code: {qrcode}")
@@ -267,7 +267,7 @@ async def run_tests():
         qrcode_id = await add_config_id_cmd.get_qrcode_id()
         logger.info (f"{__name__}: DPP QRCode ID: {qrcode_id}")
 
-        await asyncio.sleep(2)
+        # await asyncio.sleep(2)
         logger.info (f"{__name__}: Issuing DPP Auth Init command...")
         ssid="756e636c652d6a6f686e"
         psk="0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF"

--- a/micronets-gw-service/app/hostapd_adapter.py
+++ b/micronets-gw-service/app/hostapd_adapter.py
@@ -4,12 +4,16 @@ import locale
 import subprocess
 import threading
 import traceback
+import re
 from queue import Queue, Empty
 from subprocess import Popen, PIPE
 
 logger = logging.getLogger ('hostapd_adapter')
 
+
 class HostapdAdapter:
+
+    cli_event_re = re.compile ('^.*<([0-9+])>(.+)$')
 
     def __init__ (self, hostapd_cli_path, hostapd_cli_args=()):
         self.hostapd_cli_path = hostapd_cli_path
@@ -17,16 +21,17 @@ class HostapdAdapter:
         self.hostapd_cli_process = None
         self.process_reader_thread = None
         self.command_queue = None
+        self.event_loop = None
 
     async def connect(self):
         logger.info(f"HostapdAdapter:connect()")
-        event_loop = asyncio.get_event_loop ()
+        self.event_loop = asyncio.get_event_loop ()
         self.command_queue = Queue()  # https://docs.python.org/3.6/library/queue.html
         logger.info(f"HostapdAdapter:connect: Running {self.hostapd_cli_path} {self.hostapd_cli_args}")
-        
+
         self.hostapd_cli_process = Popen([self.hostapd_cli_path, *self.hostapd_cli_args],
                                          shell=False, bufsize=1,
-                                         stdin=PIPE, stdout=PIPE, stderr=subprocess.STDOUT)
+                                         stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
 
         self.process_reader_thread = threading.Thread(target=self.read_process_data)
         self.process_reader_thread.start()
@@ -39,11 +44,21 @@ class HostapdAdapter:
         while True:
             try:
                 # https://docs.python.org/3/library/io.html
-                data = self.hostapd_cli_process.stdout.readline().decode("utf-8")
+
+                # logger.debug(f"HostapdAdapter:read_process_data: Waiting on stdout.readline()...")
+                data = self.hostapd_cli_process.stdout.readline()
                 if not data:
                     logger.info(f"HostapdAdapter:read_process_data: Got EOF from hostapd_cli - exiting")
                     break
-                # logger.debug(f"HostapdAdapter:read_process_data: Read data: {data.rstrip()}")
+                line = data.decode("utf-8")
+                if len(line) == 0:
+                    continue
+                # logger.debug(f"HostapdAdapter:read_process_data: Read line: \"{line}\"")
+                cli_event_match = HostapdAdapter.cli_event_re.match(line)
+                if cli_event_match:
+                    event_data = cli_event_match.group(2)
+                    asyncio.run_coroutine_threadsafe(self.process_event(event_data), self.event_loop)
+                    continue
                 if not command:
                     try:
                         command = self.command_queue.get(block=False)
@@ -55,19 +70,26 @@ class HostapdAdapter:
                         # Don't store the first line - which contains the command (start aggregating on the next line)
                         response_data = ""
                         continue
-                    response_data = response_data + data
-                    pos = response_data.find("\n> ")
+                    response_data += line
+                    pos = response_data.find("> ")
                     if pos > 0:
                         # logger.debug (f"HostapdAdapter:read_process_data: aggregate response_data: {response_data}")
                         command_type = type(command).__name__
-                        complete_response = response_data[:pos]
+                        complete_response = response_data[:pos].rstrip()
                         logger.debug (f"HostapdAdapter:read_process_data: Found command response for {command}: {complete_response}")
+                        # logger.debug (f"HostapdAdapter:read_process_data: Calling process_response_data()...")
                         asyncio.run_coroutine_threadsafe(command.process_response_data(complete_response), 
                                                          command.event_loop)
+                        # logger.debug (f"HostapdAdapter:read_process_data: process_response_data() returned.")
                         response_data = None
                         command = None
             except Exception as ex:
-                logger.warning(f"HostapdAdapter:read_process_data: Error processing data: {ex}")
+                logger.warning(f"HostapdAdapter:read_process_data: Error processing data: {ex}", exc_info=True)
+
+
+    async def process_event(self, event_data):
+        logger.info(f"HostapdAdapter:process_event: EVENT: (\"{event_data}\")")
+
 
     async def send_command(self, command):
         if not isinstance(command, HostapdCommand):
@@ -143,16 +165,73 @@ class ListStationsCommand(HostapdCommand):
 
     async def process_response_data(self, response):
         self.sta_macs = response.splitlines()
-        self.response_future.set_result(response)
+        await super().process_response_data(response)
 
     async def get_sta_macs(self):
         await self.get_response()
         return self.sta_macs
 
 
+class DPPAddConfiguratorCommand(HostapdCommand):
+    def __init__ (self, event_loop=asyncio.get_event_loop()):
+        super().__init__(event_loop)
+        self.configurator_id = None
+
+    def get_command_string(self):
+        return "dpp_configurator_add"
+
+    async def process_response_data(self, response):
+        try:
+            self.configurator_id = int(response)
+        finally:
+            await super().process_response_data(response)
+
+    async def get_configurator_id(self):
+        await self.get_response()
+        return self.configurator_id
+
+class DPPAddQRCodeCommand(HostapdCommand):
+    def __init__ (self, qrcode, event_loop=asyncio.get_event_loop()):
+        super().__init__(event_loop)
+        self.qrcode = qrcode
+        self.qrcode_id = None
+
+    def get_command_string(self):
+        return f"dpp_qr_code {self.qrcode}"
+
+    async def process_response_data(self, response):
+        try:
+            self.qrcode_id = int(response)
+        finally:
+            await super().process_response_data(response)
+
+    def get_qrcode(self):
+        return self.qrcode
+
+    async def get_qrcode_id(self):
+        await self.get_response()
+        return self.qrcode_id
+
+
+class DPPAuthInitPSK(HostapdCommand):
+    def __init__ (self, configurator_id, qrcode_id, ssid, psk, event_loop=asyncio.get_event_loop()):
+        super().__init__(event_loop)
+        self.configurator_id = configurator_id
+        self.qrcode_id = qrcode_id
+        self.ssid = ssid
+        self.psk = psk
+
+    def get_command_string(self):
+        return f"dpp_auth_init peer={self.qrcode_id} conf=sta-psk ssid={self.ssid} psk={self.psk} configurator={self.configurator_id}"
+
+    async def process_response_data(self, response):
+        await super().process_response_data(response)
+
+
 async def run_tests():
 #        hostapd_adapter = HostapdAdapter("/usr/bin/tail", ["-f", "-n", "1", "/var/log/syslog"])
         hostapd_adapter = HostapdAdapter("/opt/micronets-hostapd/bin/hostapd_cli", [])
+
         await hostapd_adapter.connect()
         logger.info (f"{__name__}: Connected.")
 
@@ -166,20 +245,46 @@ async def run_tests():
         logger.info (f"{__name__}: Issuing ping command...")
         ping_cmd = await hostapd_adapter.send_command(PingCommand())
         response = await ping_cmd.get_response()
-        logger.info (f"{__name__}: Ping response: \"{response}\"")
+        logger.info (f"{__name__}: Ping response: {response}")
 
         await asyncio.sleep(2)
         logger.info (f"{__name__}: Issuing List Stations command...")
-        ping_cmd = await hostapd_adapter.send_command(ListStationsCommand())
-        stas = await ping_cmd.get_sta_macs()
-        logger.info (f"{__name__}: Station List: \"{stas}\"")
+        list_sta_cmd = await hostapd_adapter.send_command(ListStationsCommand())
+        stas = await list_sta_cmd.get_sta_macs()
+        logger.info (f"{__name__}: Station List: {stas}")
 
+        await asyncio.sleep(2)
+        logger.info (f"{__name__}: Issuing DPP Add Configurator command...")
+        add_config_id_cmd = await hostapd_adapter.send_command(DPPAddConfiguratorCommand())
+        configurator_id = await add_config_id_cmd.get_configurator_id()
+        logger.info (f"{__name__}: DPP Configurator ID: {configurator_id}")
+
+        await asyncio.sleep(2)
+        qrcode = "DPP:C:81/1;M:2c:d0:5a:6e:ca:3c;I:KYZRQ;K:MDkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDIgAC/nFQKV1+CErzr6QCUT0jFIno3CaTRr3BW2n0ThU4mAw=;;"
+        logger.info (f"{__name__}: Issuing DPP Add QRCode command...")
+        logger.info (f"{__name__}:   Code: {qrcode}")
+        add_config_id_cmd = await hostapd_adapter.send_command(DPPAddQRCodeCommand(qrcode))
+        qrcode_id = await add_config_id_cmd.get_qrcode_id()
+        logger.info (f"{__name__}: DPP QRCode ID: {qrcode_id}")
+
+        await asyncio.sleep(2)
+        logger.info (f"{__name__}: Issuing DPP Auth Init command...")
+        ssid="756e636c652d6a6f686e"
+        psk="0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF"
+        logger.info (f"{__name__}:   SSID: {ssid}")
+        logger.info (f"{__name__}:   PSK: {psk}")
+        dpp_auth_init_cmd = await hostapd_adapter.send_command(DPPAuthInitPSK(configurator_id, qrcode_id, ssid, psk))
+        result = await dpp_auth_init_cmd.get_response()
+        logger.info (f"{__name__}: Auth Init result: {result}")
+
+        await asyncio.sleep(2)
         logger.info (f"{__name__}: Issuing a flood of pings...")
         for x in range(1,10):
             logger.info (f"{__name__}: Issuing ping command #{x}...")
             ping_cmd = await hostapd_adapter.send_command(PingCommand())
             response = await ping_cmd.get_response()
-            logger.info (f"{__name__}: Ping response: \"{response}\"")
+            logger.info (f"{__name__}: Ping response: {response}")
+        logger.info (f"{__name__}: Tests complete.")
 
 
 if __name__ == '__main__':

--- a/micronets-gw-service/app/hostapd_adapter.py
+++ b/micronets-gw-service/app/hostapd_adapter.py
@@ -20,7 +20,7 @@ class HostapdAdapter:
         self.hostapd_cli_args = hostapd_cli_args
         self.hostapd_cli_process = None
         self.process_reader_thread = None
-
+        self.current_command = None
 
     async def connect(self):
         logger.info(f"HostapdAdapter:connect()")
@@ -34,20 +34,133 @@ class HostapdAdapter:
         self.process_reader_thread = threading.Thread(target=self.read_process_data)
         self.process_reader_thread.start()
 
-
     def read_process_data(self):
+        response_data = None
+        logger.info(f"HostapdAdapter:read_process_data: Started")
         while True:
             try:
+                # https://docs.python.org/3/library/io.html
                 data = self.hostapd_cli_process.stdout.readline().decode("utf-8")
                 if not data:
                     break
                 logger.info(f"HostapdAdapter:read_process_data: Read data: {data.rstrip()}")
+                if self.current_command:
+                    if response_data is None:
+                        # Don't store the first line (start aggregating on the next line)
+                        response_data = ""
+                        continue
+                    response_data = response_data + data
+                    pos = response_data.find("\n> ")
+                    if pos > 0:
+                        command = self.current_command
+                        logger.info (f"HostapdAdapter:read_process_data: aggregate response_data: {response_data}")
+                        command_type = type(command).__name__
+                        complete_response = response_data[:pos]
+                        logger.info (f"HostapdAdapter:read_process_data: Found command response for {command_type}: {complete_response}")
+                        response_future = asyncio.run_coroutine_threadsafe (command.process_response(complete_response), 
+                                                                            command.event_loop)
+                        logger.info (f"HostapdAdapter:read_process_data: Waiting for {command_type}.process_response() to complete...")
+                        response_future.result ()
+                        logger.info (f"HostapdAdapter:read_process_data: {command_type}.process_response() completed.")
+                        response_data = None
+                        self.current_command = None
+                else:
+                    response_data = ""
             except Exception as ex:
                 logger.warning(f"HostapdAdapter:read_process_data: Error processing data: {ex}")
 
-    def send_command(self, message):
-        self.hostapd_cli_process.stdin.write((message + '\n').encode())	
+    async def send_command(self, command):
+        if not isinstance(command, HostapdCommand):
+            raise TypeError
+        if self.current_command:
+            # TODO: Queue the command
+            raise Exception(f"send_command already processing {type(self.current_command).__name__} command")
+        self.current_command = command
+        command_string = command.get_command_string()
+        logger.info (f"HostapdAdapter:send_command: issuing command: \"{command_string}\"")
+        # Put 2 newlines on the end to force a newline on the output
+        command_string = command_string + "\n\n"
+        self.hostapd_cli_process.stdin.write(command_string.encode())
         self.hostapd_cli_process.stdin.flush()
+
+
+class HostapdCommand:
+    def __init__ (self, event_loop = asyncio.get_event_loop()):
+        self.event_loop = event_loop
+
+    def get_command_string(self):
+        """ Over-ride this method to provide the string that compromise the hostapd_cli command (without newline)"""
+        pass
+
+    async def process_response(self, response):
+        """This is where the response can be parsed for meaningful data, parsed, and have
+        memvars set to any values that want to be retained."""
+        pass
+
+class GenericHostapdMessage(HostapdCommand):
+    def __init__ (self, hostapd_command, hostapd_command_args=(), event_loop=asyncio.get_event_loop()):
+        super().__init__(event_loop)
+        self.hostapd_command = hostapd_command
+        self.hostapd_command_args = hostapd_command_args
+
+    def get_command_string(self):
+        if isinstance (self.hostapdcommand, bytes):
+            return self.hostapdcommand
+        compound_command = self.hostapdcommand
+        for arg in self.hostapd_command_args:
+            compound_command = " " + compound_command
+        return compound_command
+
+    async def process_response(self, response):
+        self.response = response
+
+
+class PingCommand(HostapdCommand):
+    def __init__ (self, event_loop=asyncio.get_event_loop()):
+        super().__init__(event_loop)
+        self.ping_response = None
+
+    def get_command_string(self):
+        return "ping"
+
+    async def process_response(self, response):
+        logger.info (f"{__name__}: Got ping response: {response.rstrip()}")
+        self.ping_response = response
+    
+    def get_response(self):
+        return self.ping_response
+
+
+class HelpCommand(HostapdCommand):
+    def __init__ (self, event_loop=asyncio.get_event_loop()):
+        super().__init__(event_loop)
+
+    def get_command_string(self):
+        return "help"
+
+    async def process_response(self, response):
+        logger.info (f"{__name__}: Got help response: {response.rstrip()}")
+
+
+async def run_tests():
+#        hostapd_adapter = HostapdAdapter("/usr/bin/tail", ["-f", "-n", "1", "/var/log/syslog"])
+        hostapd_adapter = HostapdAdapter("/opt/micronets-hostapd/bin/hostapd_cli", [])
+        await hostapd_adapter.connect()
+        logger.info (f"{__name__}: Connected.")
+
+        await asyncio.sleep(2)
+        logger.info (f"{__name__}: Issuing help command...")
+        await hostapd_adapter.send_command(HelpCommand())
+
+        await asyncio.sleep(2)
+        logger.info (f"{__name__}: Issuing ping command...")
+        ping_cmd = PingCommand()
+        await hostapd_adapter.send_command(PingCommand())
+        logger.info (f"{__name__}: Ping response: \"{ping_cmd.get_response()}\"")
+
+        await asyncio.sleep(2)
+        logger.info (f"{__name__}: Issuing ping command...")
+        await hostapd_adapter.send_command(PingCommand())
 
 if __name__ == '__main__':
     print (f"{__name__}: Starting\n")
@@ -59,15 +172,9 @@ if __name__ == '__main__':
     event_loop = asyncio.get_event_loop ()
     try:
         logger.info (f"{__name__}: Starting event loop...")
-#        hostapd_adapter = HostapdAdapter("/usr/bin/tail", ["-f", "-n", "1", "/var/log/syslog"])
-        hostapd_adapter = HostapdAdapter("/opt/micronets-hostapd/bin/hostapd_cli", [])
-        event_loop.run_until_complete(hostapd_adapter.connect())
-        logger.info (f"{__name__}: Connected.")
-        time.sleep(2)
-        logger.info (f"{__name__}: Issuing help command...")
-        hostapd_adapter.send_command("help")
-#        event_loop.run_until_complete(hostapd_adapter.relay_messages())
+        event_loop.run_until_complete(run_tests())
         event_loop.run_forever()
+        logger.info (f"{__name__}: Event loop exited")
     except Exception as Ex:
         logger.warn (f"Caught an exception: {Ex}")
 

--- a/micronets-gw-service/app/hostapd_adapter.py
+++ b/micronets-gw-service/app/hostapd_adapter.py
@@ -1,16 +1,10 @@
 import asyncio
 import logging
-import sys
 import locale
-import inspect
-import time
-import fcntl
-import os
 import subprocess
 import threading
 import traceback
 from queue import Queue, Empty
-from asyncio import BaseTransport, ReadTransport, WriteTransport, SubprocessTransport
 from subprocess import Popen, PIPE
 
 logger = logging.getLogger ('hostapd_adapter')

--- a/micronets-gw-service/app/hostapd_adapter.py
+++ b/micronets-gw-service/app/hostapd_adapter.py
@@ -1,0 +1,137 @@
+import asyncio
+import logging
+import sys
+import locale
+import inspect
+import time
+import fcntl
+import os
+from asyncio import BaseTransport, ReadTransport, WriteTransport, SubprocessTransport
+
+logger = logging.getLogger ('hostapd_adapter')
+
+class HostapdAdapter:
+
+    def __init__ (self, hostapd_cli_path, hostapd_cli_args=()):
+        self.hostapd_cli_path = hostapd_cli_path
+        self.hostapd_cli_args = hostapd_cli_args
+        self.hostapd_proc = None
+        self.transport = None
+        self.protocol = None
+
+
+    async def connect(self):
+        logger.info(f"HostapdAdapter:connect()")
+        event_loop = asyncio.get_event_loop ()
+        logger.info(f"HostapdAdapter:connect: Running {self.hostapd_cli_path} {self.hostapd_cli_args}")
+#        code = "import time,datetime; print(datetime.datetime.now());time.sleep(4);print(datetime.datetime.now());time.sleep(4);print(datetime.datetime.now());"
+#        code = 'import time,datetime; \nwhile True: \n\tprint(datetime.datetime.now())\n\ttime.sleep(1)\n'
+        transport, protocol = await event_loop.subprocess_exec(HostapdConnection, 
+                                                               self.hostapd_cli_path, *self.hostapd_cli_args,
+                                                               stdout=asyncio.subprocess.PIPE, 
+                                                               stderr=asyncio.subprocess.STDOUT, 
+                                                               stdin=asyncio.subprocess.PIPE,
+                                                               encoding="utf-8")
+        logger.info(f"HostapdAdapter:connect: subprocess_exec returned: transport {transport}, protocol {protocol}")
+        self.transport = transport
+        self.protocol = protocol
+        protocol.stdin.writelines([b"help()\n   "])
+        # protocol.stdin_pipe.flush()
+        # protocol.stdout_pipe.flush()
+        # time.sleep(1)
+        # protocol.stdin.writelines([b"topics\n"])
+        # time.sleep(1)
+        # protocol.stdin.writelines([b"modules\n"])
+        # time.sleep(1)
+        # protocol.stdin.write_eof()
+        logger.info(f"HostapdAdapter:connect done")
+
+#async def relay_messages(self):
+#        logger.info(f"HostapdAdapter:relay_messages()")
+#        done, pending = await asyncio.wait ([self.read_stdout(), self.read_stderr(), self.write_stdin()],
+#                                            return_when=asyncio.FIRST_COMPLETED)
+#        logger.info(f"HostapdAdapter:relay_messages done")
+
+
+class HostapdConnection (asyncio.Protocol):
+    def __init__(self):
+        logger.info(f"HostapdConnection constructed")
+        self.transport = None
+        self.stdin = None
+        self.stdin_pipe = None
+        self.stdout = None
+
+    def connection_made(self, transport):
+        logger.info(f"HostapdConnection:connection_made(transport: {transport})")
+        if transport:
+            self.transport = transport
+            self.protocol = transport.get_protocol()
+            logger.info(f"HostapdConnection:connection_made:   protocol: {self.protocol}")
+            logger.info(f"HostapdConnection:connection_made:   transport type: {type(transport)}")
+            
+            if isinstance(transport, asyncio.ReadTransport):
+                logger.info(f"HostapdConnection:connection_made:   transport is a ReadTransport")
+            if isinstance(transport, asyncio.WriteTransport):
+                logger.info(f"HostapdConnection:connection_made:   transport is a WriteTransport")
+            if isinstance(transport, asyncio.SubprocessTransport):
+                logger.info(f"HostapdConnection:connection_made:   transport is a SubprocessTransport")
+                self.stdin = transport.get_pipe_transport(0)
+                logger.info(f"HostapdConnection:connection_made:     stdin: {self.stdin}")
+                logger.info(f"HostapdConnection:connection_made:     stdin: write_buffer_limit: {self.stdin.get_write_buffer_limits()}")
+                # self.stdin.set_write_buffer_limits(10, 1)
+                logger.info(f"HostapdConnection:connection_made:     stdin: adjusted write_buffer_limit: {self.stdin.get_write_buffer_limits()}")
+                logger.info(f"HostapdConnection:connection_made:     stdin: write_buffer_size: {self.stdin.get_write_buffer_size()}")
+                self.stdin_pipe = self.stdin.get_extra_info("pipe", None)
+                logger.info(f"HostapdConnection:connection_made:     stdin: pipe: {self.stdin_pipe}")
+                logger.info(f"HostapdConnection:connection_made:     stdin: fileno: {self.stdin_pipe.fileno()}")
+                # logger.info(f"HostapdConnection:connection_made:     stdin members: {inspect.getmembers (self.stdin_pipe)}")
+                # make stdin non-blocking 
+                fl = fcntl.fcntl(self.stdin_pipe, fcntl.F_GETFL)
+                fcntl.fcntl(self.stdin_pipe, fcntl.F_SETFL, fl | os.O_NONBLOCK)
+                self.stdout = transport.get_pipe_transport(1)
+                logger.info(f"HostapdConnection:connection_made:     stdout: {self.stdout}")
+                self.stdout_pipe = self.stdout.get_extra_info("pipe", None)
+                logger.info(f"HostapdConnection:connection_made:     stdout: pipe: {self.stdout_pipe}")
+                logger.info(f"HostapdConnection:connection_made:     stdout: resuming reading")
+
+                fd = self.stdout_pipe.fileno()
+                fl = fcntl.fcntl(fd, fcntl.F_GETFL)
+                fcntl.fcntl(fd, fcntl.F_SETFL, fl | os.O_NONBLOCK)
+                # logger.info(f"HostapdConnection:connection_made:     stdin members: {inspect.getmembers (self.stdin)}")
+
+    def pipe_data_received(self, fd, data):
+        logger.info(f"HostapdConnection:pipe_data_received(fd: {fd}, data: {data})")
+    
+    def pipe_connection_lost(self, fd, exc):
+        logger.info(f"HostapdConnection:pipe_connection_lost(fd: {fd}, exc: {exc})")
+    
+    def process_exited(self):
+        logger.info(f"HostapdConnection:process_exited()")
+    
+    def error_received(self, exc):
+        logger.info(f"HostapdConnection:error_received(exc: {exc})")
+
+    def connection_lost(self, exc):
+        logger.info(f"HostapdConnection:connection_lost(exc: {exc})")
+
+if __name__ == '__main__':
+    print (f"{__name__}: Starting\n")
+    logging.basicConfig(level="DEBUG")
+    logger = logging.getLogger ('hostapd_adapter')
+    logger.info (f"{__name__}: Running hostapd_adapter tests")
+    logger.info (f"{__name__}: Locale: {locale.getpreferredencoding(False)}")
+
+    event_loop = asyncio.get_event_loop ()
+    try:
+        logger.info (f"Starting event loop...")
+#        hostapd_adapter = HostapdAdapter("/usr/bin/tail", ["-f", "-n", "1", "/var/log/syslog"])
+        hostapd_adapter = HostapdAdapter("/usr/bin/python", ["-u"])
+        event_loop.run_until_complete(hostapd_adapter.connect())
+        event_loop.run_forever()
+#        event_loop.run_until_complete(hostapd_adapter.relay_messages())
+        event_loop.run_forever()
+    except Exception as Ex:
+        logger.warn (f"Caught an exception: {Ex}")
+        traceback.print_exc (file=sys.stdout)
+    
+

--- a/micronets-gw-service/config.py
+++ b/micronets-gw-service/config.py
@@ -17,7 +17,7 @@ class BaseConfig:
     WEBSOCKET_SERVER_ADDRESS = "ws-proxy-api.micronets.in"
     WEBSOCKET_SERVER_PORT = 5050
     # NOTE: The WEBSOCKET_SERVER_PATH should be unique to the gateway/subscriber if using the proxy
-    WEBSOCKET_SERVER_PATH = '/micronets/v1/ws-proxy/grandpa-gw'
+    WEBSOCKET_SERVER_PATH = '/micronets/v1/ws-proxy/micronets-gw-0001'
     WEBSOCKET_TLS_CERTKEY_FILE = pathlib.Path (__file__).parent.joinpath ('lib/micronets-gw-service.pkeycert.pem')
     WEBSOCKET_TLS_CA_CERT_FILE = pathlib.Path (__file__).parent.joinpath ('lib/micronets-ws-root.cert.pem')
     FLOW_ADAPTER_NETWORK_INTERFACES_PATH = "/etc/network/interfaces"

--- a/micronets-gw-service/config.py
+++ b/micronets-gw-service/config.py
@@ -17,7 +17,7 @@ class BaseConfig:
     WEBSOCKET_SERVER_ADDRESS = "ws-proxy-api.micronets.in"
     WEBSOCKET_SERVER_PORT = 5050
     # NOTE: The WEBSOCKET_SERVER_PATH should be unique to the gateway/subscriber if using the proxy
-    WEBSOCKET_SERVER_PATH = '/micronets/v1/ws-proxy/micronets-gw-0001'
+    WEBSOCKET_SERVER_PATH = '/micronets/v1/ws-proxy/grandpa-gw'
     WEBSOCKET_TLS_CERTKEY_FILE = pathlib.Path (__file__).parent.joinpath ('lib/micronets-gw-service.pkeycert.pem')
     WEBSOCKET_TLS_CA_CERT_FILE = pathlib.Path (__file__).parent.joinpath ('lib/micronets-ws-root.cert.pem')
     FLOW_ADAPTER_NETWORK_INTERFACES_PATH = "/etc/network/interfaces"
@@ -25,7 +25,7 @@ class BaseConfig:
     FLOW_ADAPTER_APPLY_FLOWS_COMMAND = '/usr/bin/ovs-ofctl add-flows {} {}'
     FLOW_ADAPTER_ENABLED = False
     DPP_HANDLER_ENABLED = False
-
+    HOSTAPD_ADAPTER_ENABLED = False
 #
 # Mock Adapter Configurations
 #
@@ -83,6 +83,7 @@ class BaseDnsmasqConfig (BaseConfig):
     DNSMASQ_LEASE_SCRIPT = BaseConfig.SERVER_BIN_DIR.joinpath ("dnsmasq_lease_notify.py")
 
 class DnsmasqDevelopmentConfig (BaseDnsmasqConfig):
+    DEBUG = True
     LISTEN_HOST = "127.0.0.1"
     LOGFILE_PATH = None
     LOGFILE_MODE = None
@@ -90,7 +91,8 @@ class DnsmasqDevelopmentConfig (BaseDnsmasqConfig):
     DNSMASQ_RESTART_COMMAND = []
     FLOW_ADAPTER_NETWORK_INTERFACES_PATH = BaseConfig.SERVER_BASE_DIR.parent\
                                            .joinpath("filesystem/opt/micronets-gw/doc/interfaces.sample")
-    DEBUG = True
+    HOSTAPD_ADAPTER_ENABLED = True
+    HOSTAPD_CLI_PATH = '/opt/micronets-hostapd/bin/hostapd_cli'
 
 class DnsmasqDevelopmentConfigWithWebsocket (DnsmasqDevelopmentConfig):
     WEBSOCKET_CONNECTION_ENABLED = True

--- a/micronets-gw-service/config.py
+++ b/micronets-gw-service/config.py
@@ -24,6 +24,7 @@ class BaseConfig:
     # For this command, the first parameter will be the bridge name and the second the flow filename
     FLOW_ADAPTER_APPLY_FLOWS_COMMAND = '/usr/bin/ovs-ofctl add-flows {} {}'
     FLOW_ADAPTER_ENABLED = False
+    DPP_HANDLER_ENABLED = False
 
 #
 # Mock Adapter Configurations
@@ -40,6 +41,7 @@ class MockDevelopmentConfig (BaseMockConfig):
 
 class MockDevelopmentConfigWithWebsocket (MockDevelopmentConfig):
     WEBSOCKET_CONNECTION_ENABLED = True
+    DPP_HANDLER_ENABLED = True
     WEBSOCKET_SERVER_ADDRESS = "localhost"
 
 #
@@ -65,6 +67,7 @@ class IscTestingConfig (BaseIscDhcpConfig):
 
 class IscProductionConfig (BaseIscDhcpConfig):
     WEBSOCKET_CONNECTION_ENABLED = True
+    DPP_HANDLER_ENABLED = True
     DEBUG = False
     LOGGING_LEVEL = logging.INFO
     LOGFILE_MODE = 'a'
@@ -92,6 +95,7 @@ class DnsmasqDevelopmentConfig (BaseDnsmasqConfig):
 class DnsmasqDevelopmentConfigWithWebsocket (DnsmasqDevelopmentConfig):
     WEBSOCKET_CONNECTION_ENABLED = True
     WEBSOCKET_SERVER_ADDRESS = "localhost"
+    DPP_HANDLER_ENABLED = True
 
 class DnsmasqDevelopmentConfigWithFlowAdapter (DnsmasqDevelopmentConfig):
     FLOW_ADAPTER_APPLY_FLOWS_COMMAND = '/bin/echo This is where I would add flows to bridge {} from {}'
@@ -99,11 +103,13 @@ class DnsmasqDevelopmentConfigWithFlowAdapter (DnsmasqDevelopmentConfig):
 
 class DnsmasqTestingConfig (BaseDnsmasqConfig):
     WEBSOCKET_CONNECTION_ENABLED = True
+    DPP_HANDLER_ENABLED = True
     FLOW_ADAPTER_ENABLED = True
     DEBUG = True
 
 class DnsmasqProductionConfig (BaseDnsmasqConfig):
     WEBSOCKET_CONNECTION_ENABLED = True
+    DPP_HANDLER_ENABLED = True
     DEBUG = False
     LOGGING_LEVEL = logging.INFO
     LOGFILE_MODE = 'a'


### PR DESCRIPTION
This PR adds support for communicating with hostapd via the hostapd_cli interface.

Additionally, this change adds a dpp_handler and support to the ws_connector to delegate handling of websocket messages to handlers based on the eventType prefix.