### PR TITLE
Added support for destMac ACL. Renamed "dest" ACL to "destIp"

### DIFF
--- a/distribution/Makefile
+++ b/distribution/Makefile
@@ -1,6 +1,6 @@
 .PHONY: all clean distclean deb scp
 
-VERSION=1.0.43
+VERSION=1.0.45
 FBASE=micronets-gw
 SDIRS=../filesystem
 IBASE=/opt

--- a/micronets-gw-service/README.md
+++ b/micronets-gw-service/README.md
@@ -122,8 +122,8 @@ Note: Currently only data type _application/json_ is supported.
 | nameservers              | list (string)   | N        | The IP addresses of nameservers for the subnet | ["8.8.8.8", "4.4.4.4"] |
 | interface                | string          | Y        | The network interface on the gateway the subnet is associated with | "wlp2s0"
 | vlan                     | integer         | N        | The network interface on the gateway the subnet is associated with | 201
-| outRules                 | list (object)   | N        | Micronet-Rules for outbound connections for devices in the micronet | “outRules": [{“action": “allow", “dest": “api.acme.com:443/tcp"}]|
-| inRules                  | list (object)   | N        | Micronet-Rules for inbound connections for devices in the micronet | “inRules": [{“action": “allow", “source": “20.30.40.0/24", “destPort": “22/tcp"} ]|
+| outRules                 | list (object)   | N        | Micronet-Rules for outbound connections for devices in the micronet | “outRules": [{“action": “allow", “destIp": “api.acme.com:443/tcp"}]|
+| inRules                  | list (object)   | N        | Micronet-Rules for inbound connections for devices in the micronet | “inRules": [{“action": “allow", “sourceIp": “20.30.40.0/24", “destPort": “22/tcp"} ]|
 
 ##### Notes:
 * **inRules** and **outRules** are processed in the order they are defined.
@@ -177,8 +177,8 @@ Note: Currently only data type _application/json_ is supported.
 | networkAddress.ipv4      | string        | N        | The IPv4 network definition (dotted IP) | "192.168.1.42" |
 | networkAddress.ipv6      | string        | N        | The IPv6 network definition | "fe80::104c:20b6:f71a:4e55" |
 | psk                      | string        | N        | A 32-bit PSK (64 hex digits) hex-encoded WPA key or 6-63 character ASCII password | "my bad pa55word!", "0102030405...20" |
-| outRules                 | list (object) | N        | Micronet-Rules for outbound connections | “outRules": [{“action": “allow", “dest": “api.acme.com:443/tcp"}]|
-| inRules                  | list (object) | N        | Micronet-Rules for inbound connections | “inRules": [{“action": “allow", “source": “20.30.40.0/24", “destPort": “22/tcp"} ]|
+| outRules                 | list (object) | N        | Micronet-Rules for outbound connections | “outRules": [{“action": “allow", “destIp": “api.acme.com:443/tcp"}]|
+| inRules                  | list (object) | N        | Micronet-Rules for inbound connections | “inRules": [{“action": “allow", “sourceIp": “20.30.40.0/24", “destPort": “22/tcp"} ]|
 
 ##### Notes:
 * The psk field is only relevant for wifi micronets currently
@@ -360,11 +360,11 @@ All request URIs are prefixed by **/micronets/v1/gateway** unless otherwise note
 ```json
 {
     "action": string,
-    "source": [
+    "sourceIp": [
         string
     ],
     "sourcePort": string,
-    "dest": [
+    "destIp": [
         string
     ],
     "destPort": string
@@ -374,9 +374,9 @@ All request URIs are prefixed by **/micronets/v1/gateway** unless otherwise note
 | Property name            | Value          | Required | Description                             | Example      |
 | ------------------------ | -------------- | -------- | --------------------------------------- | ------------- 
 | action                   | string         | Y        | One of "deny" or "allow"                | "allow"      |
-| source                   | array (string) | N        | Source hosts/address(es)/network(s). DNS hostname, Dotted IPs, CIDR notation, and port/protocol notation support. A port with no protocol will match both TCP and UDP.  | ["8.8.8.8", "12.34.56.0/24", "www.cablelabs.com"] |
+| sourceIp                 | array (string) | N        | Source hosts/address(es)/network(s). DNS hostname, Dotted IPs, CIDR notation, and port/protocol notation support. A port with no protocol will match both TCP and UDP.  | ["8.8.8.8", "12.34.56.0/24", "www.cablelabs.com"] |
 | sourcePort               | string         | N        | Source port(s)                          | "22/tcp", "123", "1111/tcp,2222/udp" |
-| dest                     | array (string) | N        | Destination hosts/address(es)/network(s). Dotted IPs, CIDR notation, and port/protocol notation support. A port with no protocol will match both TCP and UDP.  | ["12.34.56.0/24", "www.ietf.org:80/tcp,443/tcp"] |
+| destIp                   | array (string) | N        | Destination hosts/address(es)/network(s). Dotted IPs, CIDR notation, and port/protocol notation support. A port with no protocol will match both TCP and UDP.  | ["12.34.56.0/24", "www.ietf.org:80/tcp,443/tcp"] |
 | destPort                 | string         | N        | Destination port(s)                     | "2112/tcp", "37", "1111/udp,2222/tcp"| 
 
 #### Notes:

--- a/micronets-gw-service/README.md
+++ b/micronets-gw-service/README.md
@@ -162,8 +162,17 @@ Note: Currently only data type _application/json_ is supported.
        "ipv4": string,
        "ipv6": string
     },
-    "restrictions": [
+    "outRules": [
        object
+    ],
+    "inRules": [
+       object
+    ],
+    "allowHosts": [
+       string
+    ],
+    "denyHosts": [
+       string
     ]
 }
 ```
@@ -179,6 +188,8 @@ Note: Currently only data type _application/json_ is supported.
 | psk                      | string        | N        | A 32-bit PSK (64 hex digits) hex-encoded WPA key or 6-63 character ASCII password | "my bad pa55word!", "0102030405...20" |
 | outRules                 | list (object) | N        | Micronet-Rules for outbound connections | “outRules": [{“action": “allow", “destIp": “api.acme.com:443/tcp"}]|
 | inRules                  | list (object) | N        | Micronet-Rules for inbound connections | “inRules": [{“action": “allow", “sourceIp": “20.30.40.0/24", “destPort": “22/tcp"} ]|
+| allowHosts               | list (string) | N        | A list of hosts that the device is allowed to connect to exclusively (either dotted IP address, CIDR format, DNS name, or MAC address) | ["8.8.8.8", "12.34.56.0/24", "www.example.com",  "00:23:12:0f:b0:26"] |
+| denyHosts                | list (string) | N        | A list of hosts that the device is not allowed to connect to (either dotted IP address, CIDR format, DNS name, or MAC address) | ["8.8.8.8", "12.34.56.0/24", "www.example.com",  "00:23:12:0f:b0:26"] |
 
 ##### Notes:
 * The psk field is only relevant for wifi micronets currently
@@ -186,8 +197,9 @@ Note: Currently only data type _application/json_ is supported.
 * **inRules** and **outRules** are processed in the order they are defined.
 * If **inRules** or **outRules** is non-empty, the default action is "deny"
 * If no **outRules** are defined, all outgoing device connections/packets are allowed. 
-* If no **inRules** are defined, no inbound connections are allowed other than data related to allowed outgoing connections.
+* If no **inRules** are defined, no inbound data is allowed other than data related to outgoing connections.
 * If **inRules** or **outRules** is defined, it overrides the corresponding definition in the contained micronet 
+* allowHosts/denyHosts are to be deprecated in favor of in/outRules. Don't use them together!
 
 #### Micronet Device Endpoints/Operations
 
@@ -360,30 +372,30 @@ All request URIs are prefixed by **/micronets/v1/gateway** unless otherwise note
 ```json
 {
     "action": string,
-    "sourceIp": [
-        string
-    ],
+    "sourceIp": string,
+    "sourceMac": string,
     "sourcePort": string,
-    "destIp": [
-        string
-    ],
+    "destIp": string,
+    "destMac": string,
     "destPort": string
 }
 ```
 
-| Property name            | Value          | Required | Description                             | Example      |
-| ------------------------ | -------------- | -------- | --------------------------------------- | ------------- 
-| action                   | string         | Y        | One of "deny" or "allow"                | "allow"      |
-| sourceIp                 | array (string) | N        | Source hosts/address(es)/network(s). DNS hostname, Dotted IPs, CIDR notation, and port/protocol notation support. A port with no protocol will match both TCP and UDP.  | ["8.8.8.8", "12.34.56.0/24", "www.cablelabs.com"] |
-| sourcePort               | string         | N        | Source port(s)                          | "22/tcp", "123", "1111/tcp,2222/udp" |
-| destIp                   | array (string) | N        | Destination hosts/address(es)/network(s). Dotted IPs, CIDR notation, and port/protocol notation support. A port with no protocol will match both TCP and UDP.  | ["12.34.56.0/24", "www.ietf.org:80/tcp,443/tcp"] |
-| destPort                 | string         | N        | Destination port(s)                     | "2112/tcp", "37", "1111/udp,2222/tcp"| 
+| Property name       | Value  | Required | Description                             | Example      |
+| ------------------- | ------ | -------- | --------------------------------------- | ------------- 
+| action              | string | Y        | One of "deny" or "allow"                | "allow"      |
+| sourceIp            | string | N        | Source IP hosts/address/network(s). DNS hostname, Dotted IPs, CIDR notation, and optional port/protocol notation support. A port with no protocol will match both TCP and UDP. | "8.8.8.8", "12.34.56.0/24", "www.cablelabs.com:443/tcp" |
+| sourceMac           | string | N        | Source MAC address in EUI-48 format with optional port/protocol notation support. A MAC address with no protocol will match all traffic for that host  | "b8:27:eb:75:a4:8b", "b8:27:eb:75:a4:8b:udp" |
+| sourcePort          | string | N        | Source port(s)                          | "22/tcp", "123", "1111/tcp,2222/udp" |
+| destIp              | string | N        | Destination hosts/address(es)/network(s). Dotted IPs, CIDR notation, and port/protocol notation support. A port with no protocol will match both TCP and UDP.  | "12.34.56.0/24", "www.ietf.org:80/tcp,443/tcp" |
+| destMac             | string | N        | Destination MAC address in EUI-48 format with optional port/protocol notation support. A MAC address with no protocol will match all traffic for that host  | "b8:27:eb:75:a4:8b", "b8:27:eb:75:a4:8b:80/tcp" |
+| destPort            | string | N        | Destination port(s)                     | "2112/tcp", "37", "1111/udp,2222/tcp"| 
 
 #### Notes:
 
-* hostnames will be expanded to one or more IP addresses via DNS
+* hostnames will be expanded to one or more IP addresses via DNS by the gateway
 * port designations may include "/tcp" or "/udp" to specify the protocol. If omitted, the rule will apply to both tcp and udp ports.
-* If no ports are specified in a rule, the rule applies to all ports on the host(s)
+* If no ports are specified in a rule, the rule applies to all TCP and UDP traffic on the host(s)
 
 Examples of Micronets-Rule lists:
 
@@ -391,6 +403,7 @@ Examples of Micronets-Rule lists:
 [
    {"action": "allow", "destIp": "api.acme.com:443/tcp"},
    {"action": "allow", "destIp": "1.2.3.0/24"},
+   {"action": "allow", "destMac": "00:23:12:0f:b0:26"},
    {"action": "deny"}
 ]
 ```

--- a/micronets-gw-service/app/gateway_service_api.py
+++ b/micronets-gw-service/app/gateway_service_api.py
@@ -230,16 +230,17 @@ async def check_rules (container, field_name, required):
     return rules
 
 async def check_rule (rule):
-    check_for_unrecognized_entries (rule, ['action', 'source', 'sourcePort', 'dest', 'destPort'])
+    check_for_unrecognized_entries (rule, ['action', 'sourceIp', 'sourcePort', 'destIp', 'destMac', 'destPort'])
     action = check_field (rule, 'action', str, True)
     if not (action == "allow" or action == "deny"):
         raise InvalidUsage(400, message=f"Supplied action '{action}' in rule '{rule}' is not valid "
                                         "(allowed actions are 'allow" and 'deny')
 
-    await check_hostspec (rule, 'source', False)
+    await check_hostspec (rule, 'sourceIp', False)
     check_portspec (rule, 'sourcePort', False)
 
-    await check_hostspec (rule, 'dest', False)
+    await check_hostspec (rule, 'destIp', False)
+    await check_hostspec (rule, 'destMac', False)
     check_portspec (rule, 'destPort', False)
 
     return rule

--- a/micronets-gw-service/app/utils.py
+++ b/micronets-gw-service/app/utils.py
@@ -13,6 +13,8 @@ blank_line_re = re.compile ('^\s*$', re.ASCII)
 
 comment_line_re = re.compile ('^\s*\#.*$', re.ASCII)
 
+mac_addr_re = re.compile('^(' + mac_addr_pattern + ')$')
+
 def check_json_field (json_obj, field, field_type, required):
     '''Thrown an Exception of json_obj doesn't contain field and/or it isn't of type field_type'''
     if field not in json_obj:
@@ -85,31 +87,44 @@ async def get_ipv4_hostports_for_hostportspec (hostandportspec):
     if not hostandportspec:
         return []
     hostandport = hostandportspec.split(':')
-    hostspec = hostandport[0]
-    if len(hostandport) > 1:
-        portspec_list = hostandport[1].split(',')
-    else:
-        portspec_list = None
-    host_addrs = []
-    try:
-        net = IPv4Network (hostspec)
-        if net:
-            host_addrs = [str(net)]
-    except Exception as ex:
-        # If it doesn't work as an IP4 dotted host/network, assume it's a hostname
-        addrs = await asyncio.get_event_loop().getaddrinfo (hostspec, None, family=socket.AF_INET,
-                                                            proto=socket.IPPROTO_TCP)
-        for addr in addrs:
-            host_addrs.append (addr[4][0])  # This is just the IP address portion of what's returned
-    hostandport_list = []
-    for addr in host_addrs:
-        if portspec_list:
+    if len(hostandport) >= 6:
+        mac_addr = hostandportspec[0:17]
+        portspec = hostandportspec[18:]
+        if not mac_addr_re.match(mac_addr):
+            raise Exception(f"Mac address specification '{mac_addr}' in host specification '{hostandportspec}' is invalid")
+        hostandport_list = []
+        if portspec:
+            portspec_list = portspec.split(',')
             for portspec in portspec_list:
-                if not portspec_re.match(portspec):
-                    raise Exception(f"Port specification '{portspec}' in host specification '{hostandportspec}' is invalid")
-                hostandport_list.append(addr+":"+portspec)
+                hostandport_list.append(mac_addr + ":" + portspec)
         else:
-            hostandport_list.append(addr)
+            hostandport_list.append(mac_addr)
+    else:
+        hostspec = hostandport[0]
+        if len(hostandport) == 2:
+            portspec_list = hostandport[1].split(',')
+        else:
+            portspec_list = None
+        host_addrs = []
+        try:
+            net = IPv4Network (hostspec)
+            if net:
+                host_addrs = [str(net)]
+        except Exception as ex:
+            # If it doesn't work as an IP4 dotted host/network, assume it's a hostname
+            addrs = await asyncio.get_event_loop().getaddrinfo (hostspec, None, family=socket.AF_INET,
+                                                                proto=socket.IPPROTO_TCP)
+            for addr in addrs:
+                host_addrs.append (addr[4][0])  # This is just the IP address portion of what's returned
+        hostandport_list = []
+        for addr in host_addrs:
+            if portspec_list:
+                for portspec in portspec_list:
+                    if not portspec_re.match(portspec):
+                        raise Exception(f"Port specification '{portspec}' in host specification '{hostandportspec}' is invalid")
+                    hostandport_list.append(addr+":"+portspec)
+            else:
+                hostandport_list.append(addr)
     return hostandport_list
 
 hostportspec_pattern = "(?P<ip_addr>" + ip_addr_pattern + "(?:/\d{1,3})?)" + "(?::" + portspec_pattern + ")?"
@@ -135,6 +150,21 @@ def parse_hostportspec (hostportspec):
         raise Exception(f"host-port specification '{hostportspec}' does not have a port number")
     return hostportspec_elems
 
+macportspec_pattern = "(?P<mac_addr>" + mac_addr_pattern + ")(?::" + portspec_pattern + ")?"
+# e.g. b8:27:eb:75:a4:8b, b8:27:eb:75:a4:8b:22/tcp, b8:27:eb:75:a4:8b:/tcp, b8:27:eb:75:a4:8b:25,465,587,2525
+
+macportspec_re = re.compile ("^" + macportspec_pattern + "$")
+
+def parse_macportspec (macportspec):
+    m = macportspec_re.match(macportspec)
+    if not m:
+        raise Exception(f"MAC/Port specification '{macportspec}' is invalid")
+    macportspec_elems = m.groupdict() # Will return {'mac_addr': mac, 'port': x, 'protocol': tcp/udp}
+    if 'port' not in macportspec_elems:
+        raise Exception(f"host-port specification '{macportspec}' does not have a port number")
+    return macportspec_elems
+
+
 def parse_portlistspec (portlistspec):
     portspecs = portlistspec.split(",")
     portelem_list = []
@@ -147,13 +177,16 @@ def parse_portlistspec (portlistspec):
 
 async def main():
     print("Running utils tests...")
-    hpsl = ["1.2.3.4", "5.6.7.8:99", "example.com", "bogus.org:80", "www.yahoo.com:443,80/tcp,8080", "www.example.com:443/tcp,80/tcp,7/udp"]
+    hpsl = ["1.2.3.4", "5.6.7.8:99", "example.com", "bogus.org:80", "www.yahoo.com:443,80/tcp,8080", "www.example.com:443/tcp,80/tcp,7/udp", \
+            "b8:27:eb:75:a4:8b", "b8:27:eb:75:a4:8b:80", "b8:27:eb:75:a4:8b:443,80/tcp,8080"]
     for hostportspec in hpsl:
         hostports = await get_ipv4_hostports_for_hostportspec(hostportspec)
         print (f"hostportspecs for {hostportspec}: {hostports}")
     print (f"unrolled hosts for hostportspeclist {hpsl}:")
     hostports = await unroll_hostportspec_list(hpsl)
     print (hostports)
+    print (f"Fields from parse_macportspec('b8:27:eb:75:a4:8b'): {parse_macportspec('b8:27:eb:75:a4:8b')}")
+    print (f"Fields from parse_macportspec('b8:27:eb:75:a4:8b:80/tcp'): {parse_macportspec('b8:27:eb:75:a4:8b:80/tcp')}")
     print ("Done.")
 
 if __name__ == '__main__':

--- a/micronets-gw-service/doc/dnsmasq-config.sample
+++ b/micronets-gw-service/doc/dnsmasq-config.sample
@@ -11,6 +11,6 @@ dhcp-option=tag:mockmicronet007, option:dns-server,1.2.3.4,1.2.3.5
 
 # DEVICES FOR MICRONET: mockmicronet007
 
-# Device: mydevice01, inRules: [], outRules: [], allowHosts: ["8.8.8.8", "12.34.56.0/24", "www.yahoo.com:80,465"], denyHosts: [],psk: 736b697070657220697320612076657279207665727920676f6f642063617421
-dhcp-host=00:23:12:0f:b0:26,mydevice01,set:mydevice01,192.168.1.42,10m
+# Device: mydevice03, inRules: [{"action": "allow", "destIp": "8.8.8.8"}, {"action": "allow", "destIp": "12.34.56.0/24"}, {"action": "allow", "destIp": "example.com"}, {"action": "allow", "destIp": "www.ietf.org:443/tcp"}, {"action": "allow", "destMac": "00:23:12:0f:b0:26"}, {"action": "deny"}], outRules: [], allowHosts: [], denyHosts: [],psk: None
+dhcp-host=b8:27:eb:75:a4:8a,mydevice03,set:mydevice03,192.168.1.42,10m
 

--- a/micronets-gw-service/doc/dnsmasq-config.sample
+++ b/micronets-gw-service/doc/dnsmasq-config.sample
@@ -11,6 +11,6 @@ dhcp-option=tag:mockmicronet007, option:dns-server,1.2.3.4,1.2.3.5
 
 # DEVICES FOR MICRONET: mockmicronet007
 
-# Device: mydevice03, inRules: [{"action": "allow", "destIp": "8.8.8.8"}, {"action": "allow", "destIp": "12.34.56.0/24"}, {"action": "allow", "destIp": "example.com"}, {"action": "allow", "destIp": "www.ietf.org:443/tcp"}, {"action": "allow", "destMac": "00:23:12:0f:b0:26"}, {"action": "deny"}], outRules: [], allowHosts: [], denyHosts: [],psk: None
-dhcp-host=b8:27:eb:75:a4:8a,mydevice03,set:mydevice03,192.168.1.42,10m
+# Device: mydevice01, inRules: [], outRules: [], allowHosts: ["8.8.8.8", "12.34.56.0/24", "www.yahoo.com:80,465"], denyHosts: [],psk: 736b697070657220697320612076657279207665727920676f6f642063617421
+dhcp-host=00:23:12:0f:b0:26,mydevice01,set:mydevice01,192.168.1.42,10m
 

--- a/micronets-gw-service/doc/testcases.md
+++ b/micronets-gw-service/doc/testcases.md
@@ -822,10 +822,11 @@ Note: For the sake of brevity, many of these test cases require consecutive exec
                    "ipv4": "192.168.1.42"
                },
                "outRules": [
-                  {"action": "allow", "dest": "8.8.8.8"},
-                  {"action": "allow", "dest": "12.34.56.0/24"},
-                  {"action": "allow", "dest": "example.com"},
-                  {"action": "allow", "dest": "www.ietf.org:443/tcp"},
+                  {"action": "allow", "destIp": "8.8.8.8"},
+                  {"action": "allow", "destIp": "12.34.56.0/24"},
+                  {"action": "allow", "destIp": "example.com"},
+                  {"action": "allow", "destIp": "www.ietf.org:443/tcp"},
+                  {"action": "allow", "destMac": "00:23:12:0f:b0:26"},
                   {"action": "deny"} ]
            }
         }' http://localhost:5000/micronets/v1/gateway/micronets/mockmicronet007/devices
@@ -844,10 +845,11 @@ Note: For the sake of brevity, many of these test cases require consecutive exec
                 "ipv4": "192.168.1.42"
             },
             "outRules": [
-                  {"action": "allow", "dest": "8.8.8.8"},
-                  {"action": "allow", "dest": "12.34.56.0/24"},
-                  {"action": "allow", "dest": "example.com"},
-                  {"action": "allow", "dest": "www.ietf.org:80/tcp,443/tcp"},
+                  {"action": "allow", "destIp": "8.8.8.8"},
+                  {"action": "allow", "destIp": "12.34.56.0/24"},
+                  {"action": "allow", "destIp": "example.com"},
+                  {"action": "allow", "destIp": "www.ietf.org:80/tcp,443/tcp"},
+                  {"action": "allow", "destMac": "00:23:12:0f:b0:26"},
                   {"action": "deny"} ]
         }
     }
@@ -866,10 +868,11 @@ Note: For the sake of brevity, many of these test cases require consecutive exec
                    "ipv4": "192.168.1.43"
                },
                "outRules": [
-                  {"action": "deny", "dest": "8.8.8.8"},
-                  {"action": "deny", "dest": "12.34.56.0/24"},
-                  {"action": "deny", "dest": "www.ietf.org"},
+                  {"action": "deny", "destIp": "8.8.8.8"},
+                  {"action": "deny", "destIp": "12.34.56.0/24"},
+                  {"action": "deny", "destIp": "www.ietf.org"},
                   {"action": "deny", "destPort": "25,465,587,2525"},
+                  {"action": "deny", "destMac": "00:23:12:0f:b0:26"},
                   {"action": "allow"} ]
            }
         }' http://localhost:5000/micronets/v1/gateway/micronets/mockmicronet007/devices
@@ -888,16 +891,17 @@ Note: For the sake of brevity, many of these test cases require consecutive exec
                 "ipv4": "192.168.1.43"
             },
             "outRules": [
-                {"action": "deny", "dest": "8.8.8.8"},
-                {"action": "deny", "dest": "12.34.56.0/24"},
-                {"action": "deny", "dest": "www.ietf.org"},
+                {"action": "deny", "destIp": "8.8.8.8"},
+                {"action": "deny", "destIp": "12.34.56.0/24"},
+                {"action": "deny", "destIp": "www.ietf.org"},
                 {"action": "deny", "destPort": "25,465,587,2525"},
+                {"action": "deny", "destMac": "00:23:12:0f:b0:26"},
                 {"action": "allow"} ]
         }
     }
     ```
 
-* Creating a device restricted to communicating with certain hosts (using allowHosts):
+* Creating a device restricted to communicating with certain hosts (using hosts):
 
     ```
     curl -X POST -H "Content-Type: application/json" -d '{
@@ -909,7 +913,7 @@ Note: For the sake of brevity, many of these test cases require consecutive exec
                "networkAddress": {
                    "ipv4": "192.168.1.44"
                },
-               "allowHosts": ["8.8.8.8", "12.34.56.0/24", "www.yahoo.com"]
+               "allowHosts": ["8.8.8.8", "12.34.56.0/24", "www.yahoo.com", "b8:27:eb:75:a4:8b"]
            }
         }' http://localhost:5000/micronets/v1/gateway/micronets/mockmicronet007/devices
     ```
@@ -926,13 +930,14 @@ Note: For the sake of brevity, many of these test cases require consecutive exec
             "networkAddress": {
                 "ipv4": "192.168.1.44"
             },
-            "allowHosts": ["8.8.8.8", "12.34.56.0/24", "www.yahoo.com"]        }
+            "allowHosts": ["8.8.8.8", "12.34.56.0/24", "www.yahoo.com", "b8:27:eb:75:a4:8b"]
+        }
     }
     ```
 
 * Initiating DPP onboarding (with PSK AKM):
 
-    DPP onboarding can be initiated by providing a 
+    DPP onboarding can be initiated by providing a DPP URI to the device `onboard` endpoint.
 
     ```
     curl -X PUT -H "Content-Type: application/json" -d '{


### PR DESCRIPTION
This change allows allow/denyHost specs to include 48-bit MAC addresses
 and adds allow/denyMac rules for ACL-based rules.

The old allow/deny ACL rules are now renamed allow/denyIp.
