### PR TITLE
Implemented controller and broker retry logic (NETREACH_ADAPTER_CONN_RETRY_S)

### DIFF
--- a/micronets-gw-service/config.py
+++ b/micronets-gw-service/config.py
@@ -54,6 +54,7 @@ class NetreachDefaultSettings():
     # NETREACH_ADAPTER_MQTT_BROKER_URL = "mqtts://staging.broker.controller.netreach.in:8885" # for overriding
     NETREACH_ADAPTER_MQTT_CA_CERTS = libpath.joinpath('netreach-mqtt-ca.crt')
     NETREACH_ADAPTER_CONN_START_DELAY_S = 2
+    NETREACH_ADAPTER_CONN_RETRY_S = 10
     NETREACH_ADAPTER_USE_DEVICE_PASS = True
 
 #


### PR DESCRIPTION
This should handle issues with initial controller login/setup failing.

I tested this with a completely disconnected controller. It could use some testing
 with more interesting failure cases. 

Also need to consider if a persistent backoff retry is useful/necessary.
