### PR TITLE
Add PSK caching (Issue #51 #52 #53)

### DIFF
--- a/micronets-gw-service/README.md
+++ b/micronets-gw-service/README.md
@@ -4,7 +4,6 @@ The Micronets Gateway incorporates a number of components necessary for creating
 
 In particular, this repository includes:
 
-* Plug-in logic for the ifup/down subsystem - which allows the `/etc/network/interfaces` file to be annotated with Micronets-specific keywords. This mostly includes directives for configuring interfaces and bridges with OpenVSwitch at boot-up.
 * The Micronets Gateway Service - which is used to manage the connection with the Micronets Manager, provide REST endpoints for direct or websocket-based invocation, configure the DHCP server (dnsmasq or ISC DHCP), configure network resources for the hostapd service, and issue openVSwitch/OpenFlow commands to enforce Micronet- and device-level policy.
 * Logic for creating a Debian installer files
 

--- a/micronets-gw-service/app/gateway_service_api.py
+++ b/micronets-gw-service/app/gateway_service_api.py
@@ -460,7 +460,7 @@ async def check_lease_event (lease_event):
 
     hostname = check_field (event_fields, 'hostname', str, True)
 
-@app.route (api_prefix + '/leases', methods=['PUT'])
+@app.route (api_prefix + '/dhcp-leases', methods=['PUT'])
 async def process_lease ():
     check_for_json_payload (request)
     lease_event = await request.get_json ()

--- a/micronets-gw-service/app/gateway_service_api.py
+++ b/micronets-gw-service/app/gateway_service_api.py
@@ -9,7 +9,8 @@ import logging
 
 logger = logging.getLogger ('micronets-gw-service')
 
-api_prefix = '/micronets/v1/gateway'
+# api_prefix = app.config.get('SERVER_BASE_URI')
+api_prefix = '/gateway/v1'
 
 # This installs the handler to turn the InvalidUsage exception into a response
 # See: http://flask.pocoo.org/docs/1.0/patterns/apierrors/
@@ -227,6 +228,39 @@ def check_wpa_psk(container, field_name, required):
                 raise InvalidUsage(400, message=f"Supplied WPA passphrase '{psk}' is invalid (must be 8-63 ASCII characters)")
     return psk
 
+uuid_re = re.compile('^[0-9a-fA-F]{8}(-[0-9a-fA-F]{4}){3}-[0-9a-fA-F]{12}$', re.ASCII)
+
+def check_uuid_field (json_obj, uuid_field, required):
+    uuid_field = check_field (json_obj, uuid_field, str, required)
+    if not uuid_field and not required:
+        return
+    if not uuid_re.match(uuid_field):
+        raise InvalidUsage (400, message=f"Supplied UUID '{uuid_field}' in '{json_obj}' is not valid")
+    return uuid_field
+
+hex_re = re.compile('^[0-9a-fA-F]+$', re.ASCII)
+
+def check_hex_field(json_obj, hex_field, required, length=0):
+    hex_field = check_field(json_obj, hex_field, str, required)
+    if not hex_field and not required:
+        return
+    if length and len(hex_field) != length:
+        raise InvalidUsage(400, message=f"Supplied length of hex field '{hex_field}' in '{json_obj}' is incorrect (expected {length} hex digits)")
+    if not hex_re.match(hex_field):
+        raise InvalidUsage(400, message=f"Supplied hex field '{hex_field}' in '{json_obj}' is not valid")
+    return hex_field
+
+def check_wpa_psk(container, field_name, required):
+    psk = check_field(container, field_name, str, required)
+    if psk:
+        if len(psk) == 64:
+            if not device_wpa_psk_re.match(psk):
+                raise InvalidUsage(400, message=f"Supplied WPA PSK '{psk}' is invalid (must be 64 hex digits)")
+        else:
+            if not device_wpa_passphrase_re.match(psk):
+                raise InvalidUsage(400, message=f"Supplied WPA passphrase '{psk}' is invalid (must be 8-63 ASCII characters)")
+    return psk
+
 async def check_rules (container, field_name, required):
     rules = check_field (container, field_name, (list), required)
     if rules:
@@ -432,3 +466,29 @@ async def process_lease ():
     lease_event = await request.get_json ()
     await check_lease_event (lease_event)
     return await get_conf_model ().process_dhcp_lease_event (lease_event)
+
+def check_netreach_psk_lookup(psk_lookup):
+    # "anonce": "01e376991c2d1a851a218b6c1d25bb8e04f978d985f8b8e0d62c7ea90abf1f62",
+    # "snonce": "e793f341a2371901c599ddc6f8019658751eb6bb9f38e3a1987068000a6595a9",
+    # "sta_mac": "00:c0:ca:97:d9:b1",
+    # "ap_mac": "00:c0:ca:98:98:d3",
+    # "ssid": "6e657472656163682d62657468616e792d3031",
+    # "akmp": "00000100",
+    # "pairwise": "00000010",
+    # "sta_m2": "0103007b02010b0000000000000000000301e376991c2d1a851a218b6c1d25bb8e04f978d985f8b8e0d62c7ea90abf1f620000000000000000000000000000000000000000000000000000000000000000e520c96bb122b36abaa091e9f2ea3310001c301a0100000fac040100000fac040100000fac0680000000000fac06"
+    check_for_unrecognized_entries(psk_lookup, ['anonce', 'snonce', 'sta_mac', 'ap_mac', 'ssid', 'akmp', 'pairwise', 'sta_m2'])
+    check_mac_address_field(psk_lookup, 'sta_mac', True)
+    check_mac_address_field(psk_lookup, 'ap_mac', True)
+    check_field(psk_lookup, 'anonce', str, True)
+    check_field(psk_lookup, 'snonce', str, True)
+    check_field(psk_lookup, 'ssid', str, True)
+    check_field(psk_lookup, 'akmp', str, True)
+    check_field(psk_lookup, 'pairwise', str, True)
+    check_field(psk_lookup, 'sta_m2', str, True)
+
+@app.route (api_prefix + '/netreach/psk-lookup', methods=['POST'])
+async def process_psk_entry_lookup():
+    check_for_json_payload(request)
+    psk_lookup_fields = await request.get_json()
+    check_netreach_psk_lookup(psk_lookup_fields)
+    return await get_conf_model().process_psk_lookup(psk_lookup_fields)

--- a/micronets-gw-service/app/gateway_service_conf.py
+++ b/micronets-gw-service/app/gateway_service_conf.py
@@ -400,11 +400,10 @@ class GatewayServiceConf:
             await self.ws_connection.process_dhcp_lease_event(micronet_id, device_id, action, mac_addr, net_addr)
         if self.netreach_adapter:
             await self.netreach_adapter.process_dhcp_lease_event(micronet_id, device_id, action, mac_addr, net_addr)
-
         return '', 200
 
     async def process_psk_lookup(self, psk_lookup_fields):
-        logger.info(f"GatewayServiceConf.process_psk_lookup({psk_lookup_fields})")
+        logger.info(f"GatewayServiceConf.process_psk_lookup()")
 
         if self.netreach_adapter:
             return await self.netreach_adapter.lookup_psk_for_device(psk_lookup_fields)

--- a/micronets-gw-service/app/gateway_service_conf.py
+++ b/micronets-gw-service/app/gateway_service_conf.py
@@ -392,7 +392,7 @@ class GatewayServiceConf:
         net_addr = event_fields ['networkAddress']['ipv4']
         micronet_id, device_id = await self.get_micronetid_deviceid_for_mac (mac_addr)
         if not (micronet_id and device_id):
-            logger.info (f"GatewayServiceConf.process_lease_event: ERROR: Could not find device/micronet for mac {mac_addr}")
+            logger.info (f"GatewayServiceConf.process_lease_event: Could not find device with mac {mac_addr}")
             raise InvalidUsage (404, message=f"No device found with mac address {mac_addr}")
         logger.info (f"GatewayServiceConf.process_lease_event: found micronet/device {micronet_id}/{device_id} for mac {mac_addr}")
 
@@ -402,3 +402,12 @@ class GatewayServiceConf:
             await self.netreach_adapter.process_dhcp_lease_event(micronet_id, device_id, action, mac_addr, net_addr)
 
         return '', 200
+
+    async def process_psk_lookup(self, psk_lookup_fields):
+        logger.info(f"GatewayServiceConf.process_psk_lookup({psk_lookup_fields})")
+
+        if self.netreach_adapter:
+            return await self.netreach_adapter.lookup_psk_for_device(psk_lookup_fields)
+        else:
+            return f"Could not lookup PSK {psk_lookup_fields['psk']} for MAC {psk_lookup_fields['mac']}: "\
+                    "The NetReach adapter is not enabled", 400

--- a/micronets-gw-service/app/hostapd_adapter.py
+++ b/micronets-gw-service/app/hostapd_adapter.py
@@ -57,9 +57,7 @@ class HostapdAdapter:
             logger.info(f"HostapdAdapter.update: No PSK file configured, so nothing to do")
 
         with self.hostapd_psk_path.open ('w') as outfile:
-            bss_list = list(self.get_status_var('bss').values())
-            logger.info (f"HostapdAdapter.update: Writing PSKs to {self.hostapd_psk_path.absolute ()} "
-                         f"for BSS {bss_list}")
+            logger.info (f"HostapdAdapter.update: Writing PSKs to {self.hostapd_psk_path.absolute ()}")
             outfile.write ("# THIS WPA-PSK FILE IS MANAGED BY THE MICRONETS GATEWAY SERVICE\n\n")
             outfile.write ("# MODIFICATIONS TO THIS FILE WILL BE OVER-WRITTEN\n\n")
             for micronet_id, devices in device_lists.items ():
@@ -67,11 +65,6 @@ class HostapdAdapter:
                 vlan_id = micronet.get('vlan')
                 interface_id = micronet.get('interface')
                 micronet_name = micronet.get('name')
-
-                if interface_id not in bss_list:
-                    logger.info(f"HostapdAdapter.update: micronet {micronet_id}/\"{micronet_name}\" interface {interface_id} "
-                                f"not in BSS list {bss_list} - skipping")
-                    continue
 
                 if not vlan_id:
                     logger.info(f"HostapdAdapter.update: no VLAN for micronet {micronet_id}/\"{micronet_name}\" - skipping")

--- a/micronets-gw-service/bin/dnsmasq_lease_notify.py
+++ b/micronets-gw-service/bin/dnsmasq_lease_notify.py
@@ -12,7 +12,7 @@ import pathlib
 
 lease_notifiction_host = "localhost:5000"
 lease_notification_method = "PUT"
-lease_notification_path = "/micronets/v1/gateway/leases"
+lease_notification_path = "/gateway/v1/dhcp-leases"
 
 bindir = os.path.dirname (os.path.abspath (sys.argv [0]))
 logging_filename = pathlib.Path(bindir).parent.joinpath("micronets-gw.log")

--- a/micronets-gw-service/bin/hostap_psk_delegate.py
+++ b/micronets-gw-service/bin/hostap_psk_delegate.py
@@ -6,8 +6,8 @@ import aiohttp
 import json
 
 # PSK Lookup Server config
-LOOKUP_URL_BASE = "https://staging.api.controller.netreach.in"
-LOOKUP_URL_PATH = "/v1/psks/psk-lookup"
+LOOKUP_URL_BASE = "http://localhost:5000"
+LOOKUP_URL_PATH = "/gateway/v1/netreach/psk-lookup"
 LOOKUP_URL = LOOKUP_URL_BASE + LOOKUP_URL_PATH
 
 # Some basic config

--- a/micronets-gw-service/config.py
+++ b/micronets-gw-service/config.py
@@ -56,6 +56,8 @@ class NetreachDefaultSettings():
     NETREACH_ADAPTER_CONN_START_DELAY_S = 2
     NETREACH_ADAPTER_CONN_RETRY_S = 10
     NETREACH_ADAPTER_USE_DEVICE_PASS = True
+    NETREACH_ADAPTER_PSK_CACHE_ENABLED = True
+    NETREACH_ADAPTER_PSK_CACHE_EXPIRE_S = 300
 
 #
 # Configure settings for local/development testing

--- a/micronets-gw-service/config.py
+++ b/micronets-gw-service/config.py
@@ -57,7 +57,7 @@ class NetreachDefaultSettings():
     NETREACH_ADAPTER_CONN_RETRY_S = 10
     NETREACH_ADAPTER_USE_DEVICE_PASS = True
     NETREACH_ADAPTER_PSK_CACHE_ENABLED = True
-    NETREACH_ADAPTER_PSK_CACHE_EXPIRE_S = 300
+    NETREACH_ADAPTER_PSK_CACHE_EXPIRE_S = 60
 
 #
 # Configure settings for local/development testing

--- a/micronets-gw-service/doc/testcases.md
+++ b/micronets-gw-service/doc/testcases.md
@@ -23,7 +23,7 @@ Note: For the sake of brevity, many of these test cases require consecutive exec
                 "vlan": 101,
                 "nameservers": ["8.8.8.8","4.4.4.4"]
             }
-        }' http://localhost:5000/micronets/v1/gateway/micronets
+        }' http://localhost:5000/gateway/v1/micronets
     ```
 
     Expected output: (status code 201)
@@ -60,7 +60,7 @@ Note: For the sake of brevity, many of these test cases require consecutive exec
                 "interface": "wlp2s0",
                 "vlan": 102
             }
-        }' http://localhost:5000/micronets/v1/gateway/micronets
+        }' http://localhost:5000/gateway/v1/micronets
     ```
 
     Expected output: (status code 201)
@@ -109,7 +109,7 @@ Note: For the sake of brevity, many of these test cases require consecutive exec
                 "vlan": 109
             }
         ] }
-        ' http://localhost:5000/micronets/v1/gateway/micronets
+        ' http://localhost:5000/gateway/v1/micronets
     ```
 
     Expected output: (status code 201)
@@ -151,7 +151,7 @@ Note: For the sake of brevity, many of these test cases require consecutive exec
 * Retrieve all micronets:
 
     ```
-    curl http://localhost:5000/micronets/v1/gateway/micronets
+    curl http://localhost:5000/gateway/v1/micronets
     ```
 
     Expected output: (status code 200)
@@ -199,7 +199,7 @@ Note: For the sake of brevity, many of these test cases require consecutive exec
                     "gateway":"192.168.1.2"
                 }
             }
-        }' http://localhost:5000/micronets/v1/gateway/micronets/mockmicronet007
+        }' http://localhost:5000/gateway/v1/micronets/mockmicronet007
     ```
 
     Expected output: (status code 200)
@@ -228,7 +228,7 @@ Note: For the sake of brevity, many of these test cases require consecutive exec
             "micronet": {
                 "nameservers": ["8.8.8.8", "4.4.4.4"]
             }
-        }' http://localhost:5000/micronets/v1/gateway/micronets/mockmicronet007
+        }' http://localhost:5000/gateway/v1/micronets/mockmicronet007
     ```
 
     Expected output: (status code 200)
@@ -259,7 +259,7 @@ Note: For the sake of brevity, many of these test cases require consecutive exec
                     "gateway": "192.168.1.3"
                 }
             }
-        }' http://localhost:5000/micronets/v1/gateway/micronets/mockmicronet007
+        }' http://localhost:5000/gateway/v1/micronets/mockmicronet007
     ```
 
     Expected output: (status code 200)
@@ -286,7 +286,7 @@ Note: For the sake of brevity, many of these test cases require consecutive exec
 * Deleting a micronet:
 
     ```
-    curl -X DELETE http://localhost:5000/micronets/v1/gateway/micronets/mockmicronet007
+    curl -X DELETE http://localhost:5000/gateway/v1/micronets/mockmicronet007
     ```
 
     Expected output: (status code 204)
@@ -296,7 +296,7 @@ Note: For the sake of brevity, many of these test cases require consecutive exec
 * Deleting all micronets:
 
     ```
-    curl -X DELETE http://localhost:5000/micronets/v1/gateway/micronets
+    curl -X DELETE http://localhost:5000/gateway/v1/micronets
     ```
 
     Expected output: (status code 204)
@@ -320,7 +320,7 @@ Note: For the sake of brevity, many of these test cases require consecutive exec
                 "vlan": 101,
                 "nameservers": ["8.8.8.8","4.4.4.4"]
             }
-        }' http://localhost:5000/micronets/v1/gateway/micronets
+        }' http://localhost:5000/gateway/v1/micronets
     ```
 
     Expected output: (status code 409)
@@ -345,7 +345,7 @@ Note: For the sake of brevity, many of these test cases require consecutive exec
                 "vlan": 101,
                 "nameservers": ["8.8.8.8","4.4.4.4"]
             }
-        }' http://localhost:5000/micronets/v1/gateway/micronets
+        }' http://localhost:5000/gateway/v1/micronets
     ```
 
     Expected output: (status code 400)
@@ -368,7 +368,7 @@ Note: For the sake of brevity, many of these test cases require consecutive exec
                 "interface": "wlp2s0",
                 "nameservers": ["8.8.8.8","4.4.4.4"]
             }
-        }' http://localhost:5000/micronets/v1/gateway/micronets
+        }' http://localhost:5000/gateway/v1/micronets
     ```
 
     Expected output: (status code 400)
@@ -390,7 +390,7 @@ Note: For the sake of brevity, many of these test cases require consecutive exec
                 },
                 "interface": "wlp2s0"
             }
-        }' http://localhost:5000/micronets/v1/gateway/micronets
+        }' http://localhost:5000/gateway/v1/micronets
     ```
 
     Expected output: (status code 400)
@@ -414,7 +414,7 @@ Note: For the sake of brevity, many of these test cases require consecutive exec
                 },
                 "interface": "wlp2s0"
             }
-        }' http://localhost:5000/micronets/v1/gateway/micronets
+        }' http://localhost:5000/gateway/v1/micronets
     ```
 
     Expected output: (status code 400)
@@ -438,7 +438,7 @@ Note: For the sake of brevity, many of these test cases require consecutive exec
                 },
                 "interface": "wlp2s0"
             }
-        }' http://localhost:5000/micronets/v1/gateway/micronets
+        }' http://localhost:5000/gateway/v1/micronets
     ```
     ```
     curl -X POST -H "Content-Type: application/json" -d '{
@@ -451,7 +451,7 @@ Note: For the sake of brevity, many of these test cases require consecutive exec
                 },
                 "interface": "wlp2s0"
             }
-        }' http://localhost:5000/micronets/v1/gateway/micronets
+        }' http://localhost:5000/gateway/v1/micronets
     ```
 
     Expected output: (status code 400)
@@ -476,7 +476,7 @@ Note: For the sake of brevity, many of these test cases require consecutive exec
                 "interface": "wlp2s0",
                 "vlan": 101
             }
-        }' http://localhost:5000/micronets/v1/gateway/micronets/mockmicronet007
+        }' http://localhost:5000/gateway/v1/micronets/mockmicronet007
     ```
 
     Expected output: (status code 409)
@@ -496,7 +496,7 @@ Note: For the sake of brevity, many of these test cases require consecutive exec
                     "network": "192.168.1.1234"
                 }
             }
-        }' http://localhost:5000/micronets/v1/gateway/micronets/mockmicronet007
+        }' http://localhost:5000/gateway/v1/micronets/mockmicronet007
     ```
 
     Expected output: (status code 400)
@@ -516,7 +516,7 @@ Note: For the sake of brevity, many of these test cases require consecutive exec
                     "network": "127.0.0.1"
                 }
             }
-        }' http://localhost:5000/micronets/v1/gateway/micronets/mockmicronet007
+        }' http://localhost:5000/gateway/v1/micronets/mockmicronet007
     ```
 
     Expected output: (status code 400)
@@ -538,7 +538,7 @@ Note: For the sake of brevity, many of these test cases require consecutive exec
                     "mask": "255.255.255.0"
                 }
             }
-        }' http://localhost:5000/micronets/v1/gateway/micronets
+        }' http://localhost:5000/gateway/v1/micronets
     ```
     ```
     curl -X POST -H "Content-Type: application/json" -d '{
@@ -551,7 +551,7 @@ Note: For the sake of brevity, many of these test cases require consecutive exec
                    "ipv4": "192.168.1.42"
                }
            }
-        }' http://localhost:5000/micronets/v1/gateway/micronets/mockmicronet007/devices
+        }' http://localhost:5000/gateway/v1/micronets/mockmicronet007/devices
     ```
 
     Expected output: (status code 400)
@@ -579,7 +579,7 @@ Note: For the sake of brevity, many of these test cases require consecutive exec
                    "ipv4": "192.168.1.42"
                }
            }
-        }' http://localhost:5000/micronets/v1/gateway/micronets/mockmicronet007/devices
+        }' http://localhost:5000/gateway/v1/micronets/mockmicronet007/devices
     ```
 
     Expected output: (status code 201)
@@ -622,7 +622,7 @@ Note: For the sake of brevity, many of these test cases require consecutive exec
                     }
                 }
             ]
-    }' http://localhost:5000/micronets/v1/gateway/micronets/mockmicronet007/devices
+    }' http://localhost:5000/gateway/v1/micronets/mockmicronet007/devices
     ```
 
     Expected output: (status code 201)
@@ -655,7 +655,7 @@ Note: For the sake of brevity, many of these test cases require consecutive exec
 * Retrieving all devices defined for a micronet:
 
     ```
-    curl http://localhost:5000/micronets/v1/gateway/micronets/mockmicronet007/devices
+    curl http://localhost:5000/gateway/v1/micronets/mockmicronet007/devices
     ```
 
     Expected output: (status code 200)
@@ -698,7 +698,7 @@ Note: For the sake of brevity, many of these test cases require consecutive exec
                     "ipv4": "192.168.42.43"
                 }
             }
-        }' http://localhost:5000/micronets/v1/gateway/micronets/mockmicronet007/devices
+        }' http://localhost:5000/gateway/v1/micronets/mockmicronet007/devices
     ```
 
     Expected output: (status code 200)
@@ -731,7 +731,7 @@ Note: For the sake of brevity, many of these test cases require consecutive exec
                },
                "psk": "736b697070657220697320612076657279207665727920676f6f642063617421"
            }
-        }' http://localhost:5000/micronets/v1/gateway/micronets/mockmicronet007/devices
+        }' http://localhost:5000/gateway/v1/micronets/mockmicronet007/devices
     ```
 
     Expected output: (status code 201)
@@ -759,7 +759,7 @@ Note: For the sake of brevity, many of these test cases require consecutive exec
                     "ipv4": "192.168.1.143"
                 }
             }
-        }' http://localhost:5000/micronets/v1/gateway/micronets/mockmicronet007/devices/MyDevice01
+        }' http://localhost:5000/gateway/v1/micronets/mockmicronet007/devices/MyDevice01
     ```
 
     Expected output: (status code 200)
@@ -781,7 +781,7 @@ Note: For the sake of brevity, many of these test cases require consecutive exec
 * Deleting a device:
 
     ```
-    curl -X DELETE http://localhost:5000/micronets/v1/gateway/micronets/mockmicronet007/devices/mydevice01
+    curl -X DELETE http://localhost:5000/gateway/v1/micronets/mockmicronet007/devices/mydevice01
     ```
 
     Expected output: (status code 204)
@@ -808,7 +808,7 @@ Note: For the sake of brevity, many of these test cases require consecutive exec
                   {"action": "allow", "destMac": "00:23:12:0f:b0:26"},
                   {"action": "deny"} ]
            }
-        }' http://localhost:5000/micronets/v1/gateway/micronets/mockmicronet007/devices
+        }' http://localhost:5000/gateway/v1/micronets/mockmicronet007/devices
     ```
 
     Expected output: (status code 201)
@@ -854,7 +854,7 @@ Note: For the sake of brevity, many of these test cases require consecutive exec
                   {"action": "deny", "destMac": "00:23:12:0f:b0:26"},
                   {"action": "allow"} ]
            }
-        }' http://localhost:5000/micronets/v1/gateway/micronets/mockmicronet007/devices
+        }' http://localhost:5000/gateway/v1/micronets/mockmicronet007/devices
     ```
 
     Expected output: (status code 201)
@@ -894,7 +894,7 @@ Note: For the sake of brevity, many of these test cases require consecutive exec
                },
                "allowHosts": ["8.8.8.8", "12.34.56.0/24", "www.yahoo.com", "b8:27:eb:75:a4:8b"]
            }
-        }' http://localhost:5000/micronets/v1/gateway/micronets/mockmicronet007/devices
+        }' http://localhost:5000/gateway/v1/micronets/mockmicronet007/devices
     ```
 
     Expected output: (status code 201)
@@ -924,7 +924,7 @@ Note: For the sake of brevity, many of these test cases require consecutive exec
                "akms": ["psk"],
                "uri": "DPP:C:81/1;M:2c:d0:5a:6e:ca:3c;I:KYZRQ;K:MDkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDIgAC/nFQKV1+CErzr6QCUT0jFIno3CaTRr3BW2n0ThU4mAw=;;"
            }
-       }' http://localhost:5000/micronets/v1/gateway/micronets/mockmicronet007/devices/MyDevice03/onboard
+       }' http://localhost:5000/gateway/v1/micronets/mockmicronet007/devices/MyDevice03/onboard
     ```
 
     Expected events: (when the onboard is initiated successfully/returns 200)
@@ -998,7 +998,7 @@ Note: For the sake of brevity, many of these test cases require consecutive exec
                     "ipv4": "192.168.1.4222"
                 }
             }
-        }' http://localhost:5000/micronets/v1/gateway/micronets/mockmicronet007/devices
+        }' http://localhost:5000/gateway/v1/micronets/mockmicronet007/devices
     ```
 
     Expected output: (status code 400)
@@ -1018,7 +1018,7 @@ Note: For the sake of brevity, many of these test cases require consecutive exec
                 },
                 "networkAddress": "blah"
             }
-        }' http://localhost:5000/micronets/v1/gateway/micronets/mockmicronet007/devices
+        }' http://localhost:5000/gateway/v1/micronets/mockmicronet007/devices
     ```
 
     Expected output: (status code 400)
@@ -1040,7 +1040,7 @@ Note: For the sake of brevity, many of these test cases require consecutive exec
                 },
                 "networkAddress": {}
             }
-          }'  http://localhost:5000/micronets/v1/gateway/micronets/mockmicronet007/devices
+          }'  http://localhost:5000/gateway/v1/micronets/mockmicronet007/devices
     ```
 
     Expected output: (status code 400)
@@ -1059,7 +1059,7 @@ Note: For the sake of brevity, many of these test cases require consecutive exec
                     "eui48": "00:23:12:0f:b0:26"
                 }
             }
-        }'  http://localhost:5000/micronets/v1/gateway/micronets/mockmicronet007/devices
+        }'  http://localhost:5000/gateway/v1/micronets/mockmicronet007/devices
     ```
 
     Expected output: (status code 400)
@@ -1083,7 +1083,7 @@ Note: For the sake of brevity, many of these test cases require consecutive exec
                    "ipv4": "192.168.1.42"
                }
            }
-        }' http://localhost:5000/micronets/v1/gateway/micronets/mockmicronet007/devices
+        }' http://localhost:5000/gateway/v1/micronets/mockmicronet007/devices
     ```
 
     Expected output: (status code 400)
@@ -1105,7 +1105,7 @@ Note: For the sake of brevity, many of these test cases require consecutive exec
                    "ipv4": "192.168.1.42"
                }
            }
-        }' http://localhost:5000/micronets/v1/gateway/micronets/mockmicronet007/devices
+        }' http://localhost:5000/gateway/v1/micronets/mockmicronet007/devices
     ```
 
     Expected output: (status code 400)
@@ -1126,7 +1126,7 @@ Note: For the sake of brevity, many of these test cases require consecutive exec
                "networkAddress": {
                    "ipv4": "192.168.1.42"
                }
-        }' http://localhost:5000/micronets/v1/gateway/micronets/mockmicronet007/devices/MyDevice01
+        }' http://localhost:5000/gateway/v1/micronets/mockmicronet007/devices/MyDevice01
     ```
 
     Expected output: (status code 400)
@@ -1150,7 +1150,7 @@ Note: For the sake of brevity, many of these test cases require consecutive exec
                 },
                 "nameservers": ["8.8.8.8","4.4.4.4"]
             }
-        }' http://localhost:5000/micronets/v1/gateway/micronets
+        }' http://localhost:5000/gateway/v1/micronets
     ```
     ```
     curl -X POST -H "Content-Type: application/json" -d '{
@@ -1163,7 +1163,7 @@ Note: For the sake of brevity, many of these test cases require consecutive exec
                    "ipv4": "192.168.2.42"
                }
            }
-        }' http://localhost:5000/micronets/v1/gateway/micronets/mockmicronet007/devices
+        }' http://localhost:5000/gateway/v1/micronets/mockmicronet007/devices
     ```
 
     Expected output: (status code 400)
@@ -1187,7 +1187,7 @@ Note: For the sake of brevity, many of these test cases require consecutive exec
                },
                "nameservers": ["8.8.8.8","4.4.4.4"]
            }
-        }' http://localhost:5000/micronets/v1/gateway/micronets
+        }' http://localhost:5000/gateway/v1/micronets
     ```
     ```
     curl -X POST -H "Content-Type: application/json" -d '{
@@ -1200,7 +1200,7 @@ Note: For the sake of brevity, many of these test cases require consecutive exec
                    "ipv4": "192.168.1.42"
                }
            }
-        }' http://localhost:5000/micronets/v1/gateway/micronets/mockmicronet007/devices
+        }' http://localhost:5000/gateway/v1/micronets/mockmicronet007/devices
     ```
     ```
     curl -X POST -H "Content-Type: application/json" -d '{
@@ -1213,7 +1213,7 @@ Note: For the sake of brevity, many of these test cases require consecutive exec
                    "ipv4": "192.168.1.43"
                }
            }
-        }' http://localhost:5000/micronets/v1/gateway/micronets/mockmicronet007/devices
+        }' http://localhost:5000/gateway/v1/micronets/mockmicronet007/devices
     ```
 
     Expected output: (status code 400)
@@ -1226,7 +1226,7 @@ Note: For the sake of brevity, many of these test cases require consecutive exec
 
 ### LEASE NOTIFICATION TEST CASES:
 
-Lease change notifications can be performed by posting to the `/micronets/v1/gateway/leases` endpoint.
+Lease change notifications can be performed by posting to the `/gateway/v1/leases` endpoint.
 
 ```json
 curl -X PUT -H "Content-Type: application/json" -d '{
@@ -1239,7 +1239,7 @@ curl -X PUT -H "Content-Type: application/json" -d '{
             "ipv4": "192.168.1.42"
         }, 
         "hostname": "myhost"}
-    }' http://localhost:5000/micronets/v1/gateway/leases
+    }' http://localhost:5000/gateway/v1/leases
 ```
 
 Expected output: (status code 200)


### PR DESCRIPTION
Add support for Netreach PSK lookup/caching. Changed base URL. Improved Device status reporting.
    
The new base URL is /gateway/v1/{micronets,dhcp-leases,netreach}/...
    
The DHCP lease notifications now check the PSK cache for
   device/service UUID using the MAC address (and set status
   flags accordingly).
    
MQTT notifications are transitioned into the async queue
   immediately upon reception.

Removed some dependancies on getting the BSS list from hostapd (the 
 list of wireless interfaces managed by hostapd). This could cause init 
 issues. And will likely remove interface names from the REST API.

Changed the micronets-hostapd delegate to call the NetReach agent
 instead of calling to the NetReach controller. 
