### PR TITLE
Add support for AP key registration using registration tokens (Issue #49, #57)

### DIFF
--- a/micronets-gw-service/app/netreach_adapter.py
+++ b/micronets-gw-service/app/netreach_adapter.py
@@ -85,8 +85,6 @@ class NetreachAdapter(HostapdAdapter.HostapdCLIEventHandler):
             self.priv_key = self.priv_key_file.read_text()
         else:
             self.pub_key, self.priv_key = self._generate_ecc_keypair()
-        # TODO: REMOVE ME
-        logger.info(f"NetreachAdapter: _initial_setup: Public key {self.pub_key}")
 
         if self.reg_token_file.exists():
             self.reg_token = self.reg_token_file.read_text().strip()
@@ -190,16 +188,10 @@ class NetreachAdapter(HostapdAdapter.HostapdCLIEventHandler):
             "token_expiration_request": self.token_request_time
         }
         data_json = json.dumps(data)
-        # TODO: REMOVE ME
-        logger.info(f"NetreachAdapter: _login_to_controller: data to sign: {data}")
-        logger.info(f"NetreachAdapter: _login_to_controller: data to sign (json): {data_json}")
 
         signature = self._sign_data(data_json.encode())
         enc_signature = base64.b64encode(signature).decode()
         async with httpx.AsyncClient() as httpx_client:
-            # TODO: REMOVE ME
-            logger.info(f"NetreachAdapter: _login_to_controller: signature: {signature}")
-            logger.info(f"NetreachAdapter:_login_to_controller: enc_signature: {enc_signature}")
             response = await httpx_client.post(f"{self.controller_base_url}/v1/access-points/token",
                                                headers={"x-ap-signature": enc_signature,
                                                         "content-type": "application/json"},
@@ -210,8 +202,6 @@ class NetreachAdapter(HostapdAdapter.HostapdCLIEventHandler):
                                f"{response.status_code}: {response.text}")
                 raise ValueError(res_json)
             logger.info(f"NetreachAdapter:_login_to_controller: AP SUCCESSFULLY logged into NetReach Controller ({response})")
-            logger.info(f"NetreachAdapter:_login_to_controller: Token registration response: {json.dumps(res_json, indent=4)}")
-            # TODO: censor logging of tokens
             self.ap_uuid = res_json['uuid']
             self.api_token = res_json['token']
             self.api_token_refresh = res_json['refresh_token']
@@ -225,11 +215,8 @@ class NetreachAdapter(HostapdAdapter.HostapdCLIEventHandler):
             logger.info(f"NetreachAdapter:_login_to_controller: Saved NetReach Controller API token to {self.api_token_file}")
 
     def _sign_data(self, data):
-        signature_algorithm = ec.ECDSA(hashes.SHA256())
-
-        # TODO: REMOVE ME
-        logger.info(f"NetreachAdapter: _sign_data: Signing with private key: {self.priv_key}")
         key = serialization.load_pem_private_key(self.priv_key.encode(), password=None)
+        signature_algorithm = ec.ECDSA(hashes.SHA256())
         return key.sign(data, signature_algorithm)
 
     def _connect_mqtt_listener(self):

--- a/micronets-gw-service/app/netreach_adapter.py
+++ b/micronets-gw-service/app/netreach_adapter.py
@@ -149,7 +149,7 @@ class NetreachAdapter(HostapdAdapter.HostapdCLIEventHandler):
                 logger.warning(f"NetreachAdapter._register_ap: Registration serial number mismatch: "
                                f"Found {resp_serial}, expecting {self.serial_number}")
 
-        logger.info(f"NetreachAdapter._register_ap: Successfully registered AP with pubkey \nself.pub_key}")
+        logger.info(f"NetreachAdapter._register_ap: Successfully registered AP with pubkey \n{self.pub_key}")
 
     async def _cloud_login_and_setup(self):
         logger.info(f"NetreachAdapter:_cloud_login_and_setup()")

--- a/micronets-gw-service/app/netreach_adapter.py
+++ b/micronets-gw-service/app/netreach_adapter.py
@@ -190,13 +190,11 @@ class NetreachAdapter(HostapdAdapter.HostapdCLIEventHandler):
             "token_expiration_request": self.token_request_time
         }
         data_json = json.dumps(data)
-
-        signature_algorithm = ec.ECDSA(hashes.SHA256())
-
         # TODO: REMOVE ME
-        logger.info(f"NetreachAdapter: _login_to_controller: Private key: {self.priv_key}")
-        key = serialization.load_pem_private_key(self.priv_key.encode(), password=None)
-        signature = key.sign(data_json.encode(), signature_algorithm)
+        logger.info(f"NetreachAdapter: _login_to_controller: data to sign: {data}")
+        logger.info(f"NetreachAdapter: _login_to_controller: data to sign (json): {data_json}")
+
+        signature = self._sign_data(data_json.encode())
         enc_signature = base64.b64encode(signature).decode()
         async with httpx.AsyncClient() as httpx_client:
             # TODO: REMOVE ME
@@ -225,6 +223,14 @@ class NetreachAdapter(HostapdAdapter.HostapdCLIEventHandler):
             with open(self.api_token_file, 'wt') as f:
                 f.write(self.api_token)
             logger.info(f"NetreachAdapter:_login_to_controller: Saved NetReach Controller API token to {self.api_token_file}")
+
+    def _sign_data(self, data):
+        signature_algorithm = ec.ECDSA(hashes.SHA256())
+
+        # TODO: REMOVE ME
+        logger.info(f"NetreachAdapter: _sign_data: Signing with private key: {self.priv_key}")
+        key = serialization.load_pem_private_key(self.priv_key.encode(), password=None)
+        return key.sign(data, signature_algorithm)
 
     def _connect_mqtt_listener(self):
         logger.debug(f"NetreachAdapter:_connect_mqtt_listener()")

--- a/micronets-gw-service/config.py
+++ b/micronets-gw-service/config.py
@@ -45,7 +45,7 @@ class NetreachDefaultSettings():
     libpath = BaseConfigSettings.SERVER_LIB_DIR
     NETREACH_ADAPTER_ENABLED = True
     NETREACH_ADAPTER_SERIAL_NUM_FILE = libpath.joinpath('netreach-serialnum.txt')
-    NETREACH_ADAPTER_REG_TOKEN_FILE = libpath.joinpath('netreach-regtoken.txt')
+    NETREACH_ADAPTER_REG_TOKEN_FILE = libpath.joinpath('netreach-reg-token.txt')
     NETREACH_ADAPTER_PUBLIC_KEY_FILE = libpath.joinpath('netreach-pubkey.pem')
     NETREACH_ADAPTER_PRIVATE_KEY_FILE = libpath.joinpath('netreach-privkey.pem')
     NETREACH_ADAPTER_WIFI_INTERFACE = "wlan0"

--- a/micronets-gw-service/config.py
+++ b/micronets-gw-service/config.py
@@ -50,6 +50,8 @@ class NetreachDefaultSettings():
     NETREACH_ADAPTER_PRIVATE_KEY_FILE = libpath.joinpath('netreach-privkey.pem')
     NETREACH_ADAPTER_WIFI_INTERFACE = "wlan0"
     NETREACH_ADAPTER_MAN_INTERFACE = "eth0"
+    # NETREACH_ADAPTER_MAN_ADDRESS = "1.2.3.4"
+    # NETREACH_ADAPTER_GEOLOCATION = {"latitude": "0.0", "longitude": "0.0"}
     NETREACH_ADAPTER_CONTROLLER_BASE_URL = "https://staging.api.controller.netreach.in"
     NETREACH_ADAPTER_API_KEY_FILE = libpath.joinpath('netreach-api-token.txt')
     NETREACH_ADAPTER_API_KEY_REFRESH_DAYS = 500

--- a/micronets-gw-service/config.py
+++ b/micronets-gw-service/config.py
@@ -45,9 +45,11 @@ class NetreachDefaultSettings():
     libpath = BaseConfigSettings.SERVER_LIB_DIR
     NETREACH_ADAPTER_ENABLED = True
     NETREACH_ADAPTER_SERIAL_NUM_FILE = libpath.joinpath('netreach-serialnum.txt')
+    NETREACH_ADAPTER_REG_TOKEN_FILE = libpath.joinpath('netreach-regtoken.txt')
     NETREACH_ADAPTER_PUBLIC_KEY_FILE = libpath.joinpath('netreach-pubkey.pem')
     NETREACH_ADAPTER_PRIVATE_KEY_FILE = libpath.joinpath('netreach-privkey.pem')
     NETREACH_ADAPTER_WIFI_INTERFACE = "wlan0"
+    NETREACH_ADAPTER_MAN_INTERFACE = "eth0"
     NETREACH_ADAPTER_CONTROLLER_BASE_URL = "https://staging.api.controller.netreach.in"
     NETREACH_ADAPTER_API_KEY_FILE = libpath.joinpath('netreach-api-token.txt')
     NETREACH_ADAPTER_API_KEY_REFRESH_DAYS = 500


### PR DESCRIPTION
This adds support for one-time registration of the AP's public key via use of an AP registration token.

If a file called "netreach-reg-token.txt" exists in the agent's "lib" directory, the AP will call the NetReach controller to register the AP using the registration token and the AP's serial number. The controller will only allow the pubkey to be registered if (a) the registration token is valid and verified, (b) the serial number of the AP matches the one associated with the token. As these tokens are one-time use, the AP will delete the registration token file once it's registered the public key. Note that the logic will also generate the pub/priv keypair if they don't already exist (in the files "netreach-pubkey.pem" and "netreach-privkey.pem").