### PR TITLE
Implemented support for setting the SSID from the AP Group (Issue #60)

### DIFF
--- a/micronets-gw-service/config.py
+++ b/micronets-gw-service/config.py
@@ -52,6 +52,8 @@ class NetreachDefaultSettings():
     NETREACH_ADAPTER_MAN_INTERFACE = "eth0"
     # NETREACH_ADAPTER_MAN_ADDRESS = "1.2.3.4"
     # NETREACH_ADAPTER_GEOLOCATION = {"latitude": "0.0", "longitude": "0.0"}
+    NETREACH_ADAPTER_SSID_OVERRIDE_FILE = libpath.joinpath('netreach-ssid-override.txt')
+    NETREACH_ADAPTER_UNASSIGNED_SSID = "netreach-inactive"
     NETREACH_ADAPTER_CONTROLLER_BASE_URL = "https://staging.api.controller.netreach.in"
     NETREACH_ADAPTER_API_KEY_FILE = libpath.joinpath('netreach-api-token.txt')
     NETREACH_ADAPTER_API_KEY_REFRESH_DAYS = 500


### PR DESCRIPTION
Note that this will only change the SSID on the AP when it's
 different than the value currently set on the AP.

The SSID can currently be over-written by putting an SSID
 value in the file specified by NETREACH_ADAPTER_SSID_OVERRIDE_FILE
 - currently lib/netreach-ssid-override.txt.